### PR TITLE
Prevent runtime .env from enabling parent .env scanning

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import dotenv from "dotenv";
 import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -95,7 +94,7 @@ describe("loadAllConfigs", () => {
     }
   });
 
-  it("loads parent .env values when parent scanning is enabled from the runtime .env", async () => {
+  it("does not let the runtime .env enable parent scanning", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "earveldaja-parent-env-"));
     const parentDir = join(tempDir, "parent");
     const childDir = join(parentDir, "child");
@@ -116,9 +115,42 @@ describe("loadAllConfigs", () => {
     process.chdir(childDir);
 
     try {
-      const { loadAllConfigs } = await importFreshConfig(childDir);
-      dotenv.config({ path: join(childDir, ".env"), override: true });
-      dotenv.config({ path: join(parentDir, ".env"), override: true });
+      const { loadDotenvFiles } = await importFreshConfig(childDir);
+      loadDotenvFiles();
+
+      expect(process.env.EARVELDAJA_SCAN_PARENT).toBe("true");
+      expect(process.env.EARVELDAJA_API_KEY_ID).toBeUndefined();
+      expect(process.env.EARVELDAJA_API_PUBLIC_VALUE).toBeUndefined();
+      expect(process.env.EARVELDAJA_API_PASSWORD).toBeUndefined();
+    } finally {
+      process.chdir(ORIGINAL_CWD);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads parent .env values when parent scanning is enabled in the process environment", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "earveldaja-parent-env-opt-in-"));
+    const parentDir = join(tempDir, "parent");
+    const childDir = join(parentDir, "child");
+
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(join(parentDir, ".env"), [
+      "EARVELDAJA_API_KEY_ID=parent-id",
+      "EARVELDAJA_API_PUBLIC_VALUE=parent-public",
+      "EARVELDAJA_API_PASSWORD=parent-secret",
+      "",
+    ].join("\n"));
+
+    for (const key of CONFIG_ENV_KEYS) {
+      delete process.env[key];
+    }
+    process.env.EARVELDAJA_SCAN_PARENT = "true";
+
+    process.chdir(childDir);
+
+    try {
+      const { loadDotenvFiles, loadAllConfigs } = await importFreshConfig(childDir);
+      loadDotenvFiles();
       const configs = loadAllConfigs();
 
       expect(configs).toEqual(expect.arrayContaining([expect.objectContaining({

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,7 @@ export function getConfigSearchDirs(
 
 export function loadDotenvFiles(): void {
   const loaded = new Set<string>();
+  const scanParent = process.env.EARVELDAJA_SCAN_PARENT === "true";
 
   const loadFromDirs = (dirs: string[]): void => {
     for (const dir of dirs) {
@@ -97,7 +98,7 @@ export function loadDotenvFiles(): void {
 
   loadFromDirs(getConfigSearchDirs(false));
 
-  if (process.env.EARVELDAJA_SCAN_PARENT === "true") {
+  if (scanParent) {
     loadFromDirs(getConfigSearchDirs(true));
   }
 }


### PR DESCRIPTION
### Motivation
- The dotenv loader previously read local `.env` files before checking `EARVELDAJA_SCAN_PARENT`, which allowed an untrusted working-directory `.env` to opt in to scanning parent directories and thereby leak secrets from parent `.env` files.

### Description
- Snapshot the `EARVELDAJA_SCAN_PARENT` flag at the start of `loadDotenvFiles()` and use that snapshot to decide whether to scan parent directories so local `.env` content cannot change the opt-in decision.
- Add a regression test that verifies a runtime `.env` containing `EARVELDAJA_SCAN_PARENT=true` does not cause parent `.env` values to be loaded.
- Add a test that verifies the documented opt-in still works when `EARVELDAJA_SCAN_PARENT=true` is present in the process environment before dotenv loading.
- Changes touch `src/config.ts` (opt-in snapshot) and `src/config.test.ts` (new/updated tests).

### Testing
- Ran the focused test file with `npm test -- src/config.test.ts`, and all tests passed (6 tests passed).
- The updated tests exercise both the regression (runtime `.env` cannot enable parent scanning) and the explicit opt-in behavior (process env `EARVELDAJA_SCAN_PARENT=true` enables parent scanning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c01d89f6448325807147b92196cd95)