### PR TITLE
Restrict config loading to package directories

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -34,27 +34,27 @@ async function importFreshConfig(packageRoot?: string) {
   return import("./config.js");
 }
 
-  afterEach(() => {
-    process.chdir(ORIGINAL_CWD);
-    restoreConfigEnv();
-    vi.doUnmock("./paths.js");
-    vi.resetModules();
-  });
+afterEach(() => {
+  process.chdir(ORIGINAL_CWD);
+  restoreConfigEnv();
+  vi.doUnmock("./paths.js");
+  vi.resetModules();
+});
 
 describe("getConfigSearchDirs", () => {
-  it("prioritizes the current working directory before the package root", async () => {
+  it("only includes the package root by default", async () => {
     const { getConfigSearchDirs } = await importFreshConfig();
 
-    expect(getConfigSearchDirs(false, "/tmp/runtime-cwd", "/opt/e-arveldaja-mcp")).toEqual([
-      "/tmp/runtime-cwd",
+    expect(getConfigSearchDirs(false, "/opt/e-arveldaja-mcp")).toEqual([
       "/opt/e-arveldaja-mcp",
     ]);
   });
 });
 
 describe("loadAllConfigs", () => {
-  it("finds apikey files from the current working directory", async () => {
+  it("does not load apikey files from the current working directory", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "earveldaja-config-"));
+    const packageDir = mkdtempSync(join(tmpdir(), "earveldaja-package-"));
     const apiKeyFile = join(tempDir, "apikey.txt");
 
     process.env.EARVELDAJA_SERVER = "live";
@@ -74,23 +74,13 @@ describe("loadAllConfigs", () => {
     process.chdir(tempDir);
 
     try {
-      const { loadAllConfigs } = await importFreshConfig(tempDir);
-      const configs = loadAllConfigs();
+      const { loadAllConfigs } = await importFreshConfig(packageDir);
 
-      expect(configs).toHaveLength(1);
-      expect(configs[0]).toMatchObject({
-        name: "apikey",
-        filePath: apiKeyFile,
-        config: {
-          apiKeyId: "key-id",
-          apiPublicValue: "public-value",
-          apiPassword: "secret-password",
-          baseUrl: "https://rmp-api.rik.ee/v1",
-        },
-      });
+      expect(() => loadAllConfigs()).toThrow(/No API credentials found/);
     } finally {
       process.chdir(ORIGINAL_CWD);
       rmSync(tempDir, { recursive: true, force: true });
+      rmSync(packageDir, { recursive: true, force: true });
     }
   });
 
@@ -187,7 +177,6 @@ describe("loadAllConfigs", () => {
       "",
     ].join("\n"));
     chmodSync(apiKeyFile, 0o640);
-    process.chdir(tempDir);
 
     try {
       const { loadAllConfigs } = await importFreshConfig(tempDir);
@@ -221,7 +210,6 @@ describe("loadAllConfigs", () => {
       "",
     ].join("\n"));
     chmodSync(apiKeyFile, 0o600);
-    process.chdir(tempDir);
 
     try {
       const { loadAllConfigs } = await importFreshConfig(tempDir);

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,12 +65,11 @@ function toUniqueDirs(dirs: string[]): string[] {
 
 export function getConfigSearchDirs(
   scanParent = process.env.EARVELDAJA_SCAN_PARENT === "true",
-  cwd = process.cwd(),
   packageRoot = PACKAGE_ROOT,
 ): string[] {
-  const dirs = [cwd, packageRoot];
+  const dirs = [packageRoot];
   if (scanParent) {
-    dirs.push(resolve(cwd, ".."), resolve(packageRoot, ".."));
+    dirs.push(resolve(packageRoot, ".."));
   }
   return toUniqueDirs(dirs);
 }
@@ -125,7 +124,7 @@ function parseApiKeyFile(filePath: string): { keyId: string; publicValue: string
 
 /**
  * Load all available API configurations from env vars and apikey*.txt files.
- * Scans the runtime working directory first, then the package root.
+ * Scans the package root by default.
  * Set EARVELDAJA_SCAN_PARENT=true to also scan parent directories.
  */
 export function loadAllConfigs(): NamedConfig[] {
@@ -157,8 +156,7 @@ export function loadAllConfigs(): NamedConfig[] {
     }
   }
 
-  // 3. Scan the runtime working directory first, then the package dir.
-  // Parent scan remains opt-in.
+  // 3. Scan the package dir by default. Parent scan remains opt-in.
   const searchDirs = getConfigSearchDirs();
 
   for (const dir of searchDirs) {
@@ -190,7 +188,7 @@ export function loadAllConfigs(): NamedConfig[] {
   if (configs.length === 0) {
     throw new Error(
       "No API credentials found. Set EARVELDAJA_API_KEY_ID/EARVELDAJA_API_PUBLIC_VALUE/EARVELDAJA_API_PASSWORD " +
-      "environment variables, or place apikey*.txt files in the working directory."
+      "environment variables, or place apikey*.txt files in the package directory."
     );
   }
 


### PR DESCRIPTION
### Motivation
- The previous config loader trusted `process.cwd()` and eagerly loaded `.env` and `apikey*.txt` files from the runtime working directory, allowing local config/credential injection when the server is launched from an untrusted folder.
- The change aims to eliminate implicit trust of the current working directory while preserving the existing package-root and opt-in parent-directory behaviors.

### Description
- Stop including the runtime current working directory in `getConfigSearchDirs()` so default discovery only searches the package root and optionally its parent when `EARVELDAJA_SCAN_PARENT=true`.
- Keep parent-directory scanning as an explicit opt-in and preserve `loadDotenvFiles()` and `loadAllConfigs()` scanning of the `getConfigSearchDirs()` result, but change the default to package-only.
- Update user-facing error text to instruct placing `apikey*.txt` files in the package directory instead of the working directory.
- Update `src/config.test.ts` to assert that credentials in the current working directory are ignored by default and to adapt other tests to the new package-root-first behavior.

### Testing
- Built the project with `npm run build` which completed successfully.
- Ran the full test suite with `npm test` and all tests passed (32 test files, 383 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0211373f08325b7919aaec50cc419)