### PR TITLE
Revalidate receipt files before parse/upload to close TOCTOU gap

### DIFF
--- a/src/tools/receipt-inbox.test.ts
+++ b/src/tools/receipt-inbox.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { readFile } from "fs/promises";
+import { validateFilePath } from "../file-validation.js";
 import {
   buildDryRunCreatedInvoicePreview,
   classifyReceiptDocument,
@@ -22,7 +24,22 @@ import {
   normalizeCounterpartyName,
   scoreTransactionToInvoice,
   suggestBookingInternal,
+  readValidatedReceiptFile,
+  revalidateReceiptFilePath,
 } from "./receipt-inbox.js";
+
+vi.mock("../file-validation.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../file-validation.js")>()),
+  validateFilePath: vi.fn(),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("fs/promises")>()),
+  readFile: vi.fn(),
+}));
+
+const mockedValidateFilePath = vi.mocked(validateFilePath);
+const mockedReadFile = vi.mocked(readFile);
 
 function makeTx(overrides: Partial<{
   type: string;
@@ -56,6 +73,41 @@ describe("buildDryRunCreatedInvoicePreview", () => {
       confirmed: false,
       uploaded_document: false,
     });
+  });
+});
+
+describe("receipt file revalidation", () => {
+  it("revalidates the scanned path before re-reading the file", async () => {
+    mockedValidateFilePath.mockResolvedValueOnce("/tmp/revalidated.pdf");
+
+    await expect(revalidateReceiptFilePath({
+      name: "receipt.pdf",
+      path: "/tmp/original.pdf",
+      extension: ".pdf",
+      file_type: "pdf",
+      size_bytes: 123,
+      modified_at: "2026-03-01T00:00:00.000Z",
+    })).resolves.toBe("/tmp/revalidated.pdf");
+
+    expect(mockedValidateFilePath).toHaveBeenCalledWith("/tmp/original.pdf", [".pdf"], 50 * 1024 * 1024);
+  });
+
+  it("reads the revalidated path instead of the originally scanned path", async () => {
+    mockedValidateFilePath.mockResolvedValueOnce("/tmp/revalidated.pdf");
+    mockedReadFile.mockResolvedValueOnce(Buffer.from("pdf"));
+
+    await expect(readValidatedReceiptFile({
+      name: "receipt.pdf",
+      path: "/tmp/original.pdf",
+      extension: ".pdf",
+      file_type: "pdf",
+      size_bytes: 123,
+      modified_at: "2026-03-01T00:00:00.000Z",
+    })).resolves.toEqual(Buffer.from("pdf"));
+
+    expect(mockedValidateFilePath).toHaveBeenCalledWith("/tmp/original.pdf", [".pdf"], 50 * 1024 * 1024);
+    expect(mockedReadFile).toHaveBeenCalledWith("/tmp/revalidated.pdf");
+    expect(mockedReadFile).not.toHaveBeenCalledWith("/tmp/original.pdf");
   });
 });
 

--- a/src/tools/receipt-inbox.ts
+++ b/src/tools/receipt-inbox.ts
@@ -209,6 +209,15 @@ export function buildDryRunCreatedInvoicePreview(invoiceNumber: string) {
   };
 }
 
+export async function revalidateReceiptFilePath(file: ReceiptFileInfo): Promise<string> {
+  return validateFilePath(file.path, [file.extension], MAX_RECEIPT_SIZE);
+}
+
+export async function readValidatedReceiptFile(file: ReceiptFileInfo): Promise<Buffer> {
+  const validatedPath = await revalidateReceiptFilePath(file);
+  return readFile(validatedPath);
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -440,7 +449,8 @@ async function scanReceiptFolderInternal(folderPath: string, fileTypes?: FileTyp
 }
 
 async function extractReceiptFields(file: ReceiptFileInfo): Promise<ExtractedReceiptFields> {
-  const parsedDocument = await parseDocument(file.path);
+  const validatedPath = await revalidateReceiptFilePath(file);
+  const parsedDocument = await parseDocument(validatedPath);
   return extractReceiptFieldsFromText(parsedDocument.text, file.name);
 }
 
@@ -621,7 +631,7 @@ async function createAndMaybeMatchPurchaseInvoice(
 
   let uploadedDocument = false;
   if (createdInvoice.id) {
-    const contents = (await readFile(file.path)).toString("base64");
+    const contents = (await readValidatedReceiptFile(file)).toString("base64");
     await api.purchaseInvoices.uploadDocument(createdInvoice.id, file.name, contents);
     uploadedDocument = true;
     notes.push("Uploaded source document to created purchase invoice.");


### PR DESCRIPTION
### Motivation
- The receipt inbox scanned and validated file paths during folder scan but later read `file.path` directly, creating a TOCTOU window allowing a local attacker to swap files after scan and bypass extension/size/allowed-root checks.
- The change is intended to close that scan-to-read gap with minimal surface-area changes so existing batch processing semantics are preserved.

### Description
- Added `revalidateReceiptFilePath(file: ReceiptFileInfo)` and `readValidatedReceiptFile(file: ReceiptFileInfo)` helpers that call `validateFilePath` immediately before use and read the resolved path.
- Updated `extractReceiptFields` to revalidate the file path before calling `parseDocument` and updated invoice upload flow in `createAndMaybeMatchPurchaseInvoice` to read the revalidated path before uploading.
- Added unit tests that mock `validateFilePath` and `fs/promises.readFile` and assert that revalidation is performed and the revalidated path is used for reads.
- Changes are limited to `src/tools/receipt-inbox.ts` and `src/tools/receipt-inbox.test.ts` and do not modify higher-level batch logic or API interactions.

### Testing
- Ran unit tests with `npm test -- --run src/tools/receipt-inbox.test.ts` and all tests in that file passed (63 tests passed).
- Ran the TypeScript build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c02264270c8325ac7b031ca47bf085)