### PR TITLE
Validate and bound max_date_gap for inter-account reconciliation

### DIFF
--- a/src/tools/bank-reconciliation.test.ts
+++ b/src/tools/bank-reconciliation.test.ts
@@ -392,6 +392,20 @@ describe("reconcile_inter_account_transfers", () => {
     expect(payload.pairs[0]!.match_reasons).toContain("exact_amount");
   });
 
+  it("rejects oversized max_date_gap values", async () => {
+    const { handler } = setupInterAccountTool({
+      transactions: [
+        { id: 5, status: "PROJECT", is_deleted: false, type: "C", amount: 500, date: "2026-03-15", accounts_dimensions_id: 100, bank_account_no: "EE987654321098765432" },
+        { id: 6, status: "PROJECT", is_deleted: false, type: "D", amount: 500, date: "2026-03-20", accounts_dimensions_id: 200, bank_account_no: "EE123456789012345678" },
+      ],
+      bankAccounts,
+    });
+
+    await expect(handler({ max_date_gap: 1000000 })).rejects.toThrow(
+      "max_date_gap must be an integer between 0 and 31."
+    );
+  });
+
   it("does not match when date gap exceeds max_date_gap", async () => {
     const { handler } = setupInterAccountTool({
       transactions: [

--- a/src/tools/bank-reconciliation.ts
+++ b/src/tools/bank-reconciliation.ts
@@ -7,6 +7,18 @@ import { readOnly, batch } from "../annotations.js";
 import { reportProgress } from "../progress.js";
 import { buildInterAccountJournalIndex } from "./inter-account-utils.js";
 
+const MAX_INTER_ACCOUNT_DATE_GAP_DAYS = 31;
+
+function validateInterAccountDateGap(maxDateGap: number | undefined): number {
+  const value = maxDateGap ?? 1;
+
+  if (!Number.isInteger(value) || value < 0 || value > MAX_INTER_ACCOUNT_DATE_GAP_DAYS) {
+    throw new Error(`max_date_gap must be an integer between 0 and ${MAX_INTER_ACCOUNT_DATE_GAP_DAYS}.`);
+  }
+
+  return value;
+}
+
 /** Normalize text for fuzzy company name matching: lowercase, strip diacritics, collapse whitespace */
 function normalizeCompanyName(name: string): string {
   return name.trim().toLowerCase()
@@ -353,7 +365,8 @@ export function registerBankReconciliationTools(server: McpServer, api: ApiConte
     "Already-handled transfers are reported in the output for review/deletion.",
     {
       execute: z.boolean().optional().describe("Actually confirm matched pairs (default false = dry run)"),
-      max_date_gap: z.number().optional().describe("Maximum days between C and D transaction dates (default 1)"),
+      max_date_gap: z.number().int().min(0).max(MAX_INTER_ACCOUNT_DATE_GAP_DAYS).optional()
+        .describe(`Maximum days between C and D transaction dates (default 1, max ${MAX_INTER_ACCOUNT_DATE_GAP_DAYS})`),
       target_accounts_dimensions_id: z.number().optional().describe(
         "For one-sided transfers (no matching D/C pair), specify the target bank account dimension ID. " +
         "Required when there are 3+ bank accounts and counterparty IBAN is missing."
@@ -362,7 +375,7 @@ export function registerBankReconciliationTools(server: McpServer, api: ApiConte
     { ...batch, title: "Reconcile Inter-Account Transfers" },
     async ({ execute, max_date_gap, target_accounts_dimensions_id }) => {
       const dryRun = execute !== true;
-      const maxGap = max_date_gap ?? 1;
+      const maxGap = validateInterAccountDateGap(max_date_gap);
 
       const [allTx, bankAccounts, accountDimensions, invoiceInfo] = await Promise.all([
         api.transactions.listAll(),


### PR DESCRIPTION
### Motivation

- Prevent user-controlled `max_date_gap` from driving a large loop in `findExistingJournal` and enabling CPU-bound DoS. 
- Enforce a safe, documented upper bound for date proximity checks used during inter-account transfer duplicate detection.

### Description

- Add `MAX_INTER_ACCOUNT_DATE_GAP_DAYS = 31` and a validator `validateInterAccountDateGap` that requires an integer in `0..31` and returns the effective value. 
- Tighten the tool input schema to `z.number().int().min(0).max(MAX_INTER_ACCOUNT_DATE_GAP_DAYS)` for `max_date_gap` and use `validateInterAccountDateGap` in the handler instead of using the raw value. 
- Add a regression test `rejects oversized max_date_gap values` to `src/tools/bank-reconciliation.test.ts` verifying that oversized inputs are rejected.

### Testing

- Ran the targeted test suite with `npx vitest run src/tools/bank-reconciliation.test.ts`, and all tests passed (25 tests passed). 
- Built the project with `npm run build` (TypeScript compilation) which completed successfully. 
- Files changed: `src/tools/bank-reconciliation.ts` and `src/tools/bank-reconciliation.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c022645ad88325bf63de7ff104e3b7)