### PR TITLE
Fix roundMoney for extreme magnitudes

### DIFF
--- a/src/money.test.ts
+++ b/src/money.test.ts
@@ -38,6 +38,13 @@ describe("roundMoney", () => {
     expect(roundMoney(123456.789)).toBe(123456.79);
   });
 
+  it("does not zero extremely large values", () => {
+    expect(roundMoney(1e19)).toBe(1e19);
+    expect(roundMoney(-1e19)).toBe(-1e19);
+    expect(roundMoney(1e21)).toBe(1e21);
+    expect(roundMoney(-1e21)).toBe(-1e21);
+  });
+
   it("handles already-rounded values", () => {
     expect(roundMoney(1.23)).toBe(1.23);
     expect(roundMoney(100)).toBe(100);

--- a/src/money.ts
+++ b/src/money.ts
@@ -6,6 +6,14 @@
 export const roundMoney = (v: number): number => {
   if (v === 0 || !Number.isFinite(v)) return 0;
   const abs = Math.abs(v);
+
+  // Once the scaled value reaches 1e21, Number stringification switches to
+  // exponential notation and the string-exponent trick becomes invalid
+  // (e.g. Number(Math.round(...)) + "e-2" => "1e+21e-2"). At that magnitude
+  // the IEEE 754 spacing is already much larger than 0.01, so the original
+  // value is the closest representable cent-rounded result.
+  if (abs >= 1e19) return v || 0;
+
   const rounded = Number(Math.round(parseFloat(abs + "e2")) + "e-2");
   return (v < 0 ? -rounded : rounded) || 0;
 };


### PR DESCRIPTION
### Motivation
- A recent string-exponent rounding trick can produce invalid numeric strings for very large values (e.g. "1e+21e-2") which `Number()` turns into `NaN` and then `|| 0` silently zeros huge amounts.
- The intent is to avoid silently returning `0` for extreme magnitudes while preserving correct cent-rounding behavior for ordinary monetary values.

### Description
- Add a guard in `src/money.ts` that returns the original representable value for magnitudes where the string-exponent trick becomes invalid: `if (abs >= 1e19) return v || 0;`.
- Keep the existing string-exponent rounding path for smaller values (`Math.round(parseFloat(abs + "e2")) + "e-2"`).
- Add regression tests in `src/money.test.ts` to verify extremely large positive and negative inputs (e.g. `1e19`, `1e21`) do not collapse to zero and that existing rounding behavior remains covered.

### Testing
- Ran `npm run build` which completed successfully (`tsc` build passed). 
- Ran `npm test` and the test suite passed (all tests ran; repository reports 384 tests passed).
- Attempted `npm test -- --runInBand` which failed because the Vitest CLI in this repo does not accept `--runInBand` (reported `Unknown option --runInBand`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0226390d08325a43408f666084e59)