### PR TITLE
[codex] Improve workflow action UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ graph TB
     subgraph Server["MCP Server (Node.js + TypeScript)"]
         Entry["index.ts\nMCP entry point"]
 
-        subgraph Tools["tools/ — 109 tools across 15 modules"]
+        subgraph Tools["tools/ — 111 tools across 16 modules"]
             CRUD["crud-tools.ts\nBasic CRUD"]
             PDF["pdf-workflow.ts\nInvoice PDF"]
             OCR["receipt-extraction.ts\nReceipt OCR"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Guided workflow continuation** — `continue_accounting_workflow` reads a previous accounting inbox or workflow response and returns the next user-facing action: one question, one review item, one approval card, or one safe dry-run call.
+- **Standard workflow action envelope** — workflow recommendation and accounting inbox responses now include a `workflow_action_v1` block with `done`, `needs_decision`, `needs_review`, `recommended_next_action`, `available_actions`, and `approval_previews`.
+
 ## [0.11.8] - 2026-04-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # e-arveldaja MCP Server
 
 TypeScript MCP server for the Estonian e-arveldaja (RIK e-Financials) REST API.
-109 tools, 15 workflow prompts, 12 resources across 11 modules. Supports multiple companies/accounts.
+111 tools, 15 workflow prompts, 12 resources across 12 modules. Supports multiple companies/accounts.
 
 ## Quick Start
 
@@ -260,5 +260,5 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 const transport = new StdioClientTransport({ command: "node", args: ["dist/index.js"] });
 const client = new Client({ name: "test", version: "1.0.0" });
 await client.connect(transport);
-const { tools } = await client.listTools(); // 109 tools
+const { tools } = await client.listTools(); // 111 tools
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/e-arveldaja-mcp)](https://www.npmjs.com/package/e-arveldaja-mcp)
 
-MCP server for the Estonian e-arveldaja (RIK e-Financials) REST API. 109 tools, 15 workflow prompts, 12 resources. Works with any MCP client — Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, Cline, and others.
+MCP server for the Estonian e-arveldaja (RIK e-Financials) REST API. 111 tools, 15 workflow prompts, 12 resources. Works with any MCP client — Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, Cline, and others.
 
-> **v0.11 adds accounting inbox autopilot and review resolution.** `run_accounting_inbox_dry_runs` scans a workspace and chains safe dry-run steps into one preview, `resolve_accounting_review_item` + `prepare_accounting_review_action` turn review items into ready-to-approve tool calls, and `save_auto_booking_rule` persists stable supplier booking defaults to `accounting-rules.md`. See the [changelog](CHANGELOG.md) for full details.
+> **v0.11 adds accounting inbox autopilot and review resolution.** `run_accounting_inbox_dry_runs` scans a workspace and chains safe dry-run steps into one preview, `continue_accounting_workflow` turns the previous response into the next question/review/approval action, `resolve_accounting_review_item` + `prepare_accounting_review_action` turn review items into ready-to-approve tool calls, and `save_auto_booking_rule` persists stable supplier booking defaults to `accounting-rules.md`. See the [changelog](CHANGELOG.md) for full details.
 >
 > **v0.10.0 is a major update.** Large parts of the codebase have been rewritten — credential management, bank reconciliation, audit logging, and batch workflows all received significant changes. **You may need to re-add your API credentials** after updating, as the credential storage has moved from reading `apikey*.txt` directly to `.env` files. Your existing `apikey*.txt` files will be detected automatically and the server will offer to import them on first start.
 
@@ -160,6 +160,8 @@ Once the MCP server is connected, just talk to your AI assistant in natural lang
 > "Scan this workspace and tell me what can be done automatically, what needs one decision, and what needs accountant review"
 
 This is the recommended first step for non-accountants. The assistant will use the accounting inbox flow to detect likely CAMT files, Wise CSV exports, and receipt folders, propose safe `dry-run` steps in the right order, and ask only the smallest missing follow-up questions with recommended defaults first.
+
+Accounting inbox and workflow recommendation responses include a `workflow` block with `done`, `needs_decision`, `needs_review`, `recommended_next_action`, `available_actions`, and `approval_previews` so clients can continue from one compact next step instead of choosing among all tools manually.
 
 ### Enter purchase invoices from PDF files
 

--- a/src/http-client.test.ts
+++ b/src/http-client.test.ts
@@ -149,6 +149,56 @@ describe("HttpClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    [400, "/purchase_invoices", "Validate the request body", "list_account_dimensions"],
+    [422, "/journals", "Validate the request body", "list_accounts"],
+    [403, "/clients", "Check API token permissions", "get_setup_instructions"],
+    [404, "/clients/123", "Verify that the referenced record still exists", "search_client"],
+    [409, "/purchase_invoices", "Resolve the conflict before retrying", "detect_duplicate_purchase_invoice"],
+  ])("adds recovery hints and next actions for HTTP %i", async (status, path, hintText, nextTool) => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ messages: ["Upstream validation text"] }), {
+        status,
+        headers: { "content-type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new HttpClient(config);
+
+    try {
+      await client.get(path);
+      expect.fail("should have thrown");
+    } catch (err) {
+      const e = err as Error & { recovery_hint?: string; next_actions?: Array<{ tool: string }> };
+      expect(e.recovery_hint).toContain(hintText);
+      expect(e.next_actions).toEqual(expect.arrayContaining([
+        expect.objectContaining({ tool: nextTool }),
+      ]));
+    }
+  });
+
+  it("adds a rate-limit recovery hint without advertising a non-existent retry tool", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn()
+      .mockResolvedValue(new Response(JSON.stringify({ messages: ["rate limited"] }), {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new HttpClient(config);
+    const promise = client.post("/transactions", { amount: 10 });
+    const expectation = expect(promise).rejects.toMatchObject({
+      recovery_hint: expect.stringContaining("Wait before retrying"),
+      next_actions: undefined,
+    });
+
+    await vi.runAllTimersAsync();
+
+    await expectation;
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
   it("blocks a request before fetch when the request guard rejects", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -22,18 +22,34 @@ export class HttpError extends Error {
    * serialization forwards this property to the MCP response.
    */
   readonly upstream_detail?: string;
+  readonly recovery_hint?: string;
+  readonly next_actions?: Array<{
+    tool: string;
+    args?: Record<string, unknown>;
+    why: string;
+  }>;
 
   constructor(
     message: string,
     public readonly status: number | "network",
     public readonly method: HttpMethod,
     public readonly path: string,
-    options?: { upstream_detail?: string },
+    options?: {
+      upstream_detail?: string;
+      recovery_hint?: string;
+      next_actions?: Array<{ tool: string; args?: Record<string, unknown>; why: string }>;
+    },
   ) {
     super(message);
     this.name = "HttpError";
     if (options?.upstream_detail !== undefined) {
       this.upstream_detail = options.upstream_detail;
+    }
+    if (options?.recovery_hint !== undefined) {
+      this.recovery_hint = options.recovery_hint;
+    }
+    if (options?.next_actions !== undefined) {
+      this.next_actions = options.next_actions;
     }
   }
 }
@@ -82,6 +98,163 @@ export class HttpClient {
 
   private static shouldRetryStatus(method: HttpMethod, status: number): boolean {
     return status === 429 || (method === "GET" && status >= 500);
+  }
+
+  private static getResourceName(path: string): string | undefined {
+    return path.split("?")[0]!.split("/").filter(Boolean)[0];
+  }
+
+  private static getPathId(path: string): number | undefined {
+    const raw = path.split("?")[0]!.split("/").filter(Boolean)[1];
+    if (!raw) return undefined;
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  }
+
+  private static listActionForPath(path: string): { tool: string; why: string } | undefined {
+    switch (HttpClient.getResourceName(path)) {
+      case "clients":
+        return { tool: "list_clients", why: "List clients and verify the target client ID." };
+      case "products":
+        return { tool: "list_products", why: "List products and verify the target product ID." };
+      case "journals":
+        return { tool: "list_journals", why: "List journals and verify the target journal ID/status." };
+      case "transactions":
+        return { tool: "list_transactions", why: "List transactions and verify the target transaction ID/status." };
+      case "sale_invoices":
+        return { tool: "list_sale_invoices", why: "List sale invoices and verify the target invoice ID/status." };
+      case "purchase_invoices":
+        return { tool: "list_purchase_invoices", why: "List purchase invoices and verify the target invoice ID/status." };
+      default:
+        return undefined;
+    }
+  }
+
+  private static recoveryActionsForNotFound(path: string): Array<{ tool: string; args?: Record<string, unknown>; why: string }> {
+    const id = HttpClient.getPathId(path);
+    const listAction = HttpClient.listActionForPath(path);
+    const actions: Array<{ tool: string; args?: Record<string, unknown>; why: string }> = [];
+
+    if (id !== undefined) {
+      const resource = HttpClient.getResourceName(path);
+      const singular = resource?.endsWith("s") ? resource.slice(0, -1) : resource;
+      if (singular && ["client", "product", "journal", "transaction"].includes(singular)) {
+        actions.push({
+          tool: `get_${singular}`,
+          args: { id },
+          why: "Re-read the record by ID to confirm whether it still exists.",
+        });
+      }
+      if (resource === "sale_invoices") {
+        actions.push({ tool: "get_sale_invoice", args: { id }, why: "Re-read the sale invoice by ID." });
+      }
+      if (resource === "purchase_invoices") {
+        actions.push({ tool: "get_purchase_invoice", args: { id }, why: "Re-read the purchase invoice by ID." });
+      }
+    }
+
+    if (HttpClient.getResourceName(path) === "clients") {
+      actions.push(
+        { tool: "search_client", args: { name: "<client name>" }, why: "Search by name when the stored client ID may be stale." },
+        { tool: "find_client_by_code", args: { code: "<registry code>" }, why: "Find the current client by registry code." },
+      );
+    }
+    if (listAction) actions.push(listAction);
+    return actions;
+  }
+
+  private static recoveryActionsForValidation(path: string): Array<{ tool: string; args?: Record<string, unknown>; why: string }> {
+    const actions: Array<{ tool: string; args?: Record<string, unknown>; why: string }> = [
+      { tool: "list_accounts", why: "Verify account IDs and whether the account requires dimensions." },
+      { tool: "list_account_dimensions", why: "Find required sub-account/dimension IDs for dimensional accounts." },
+      { tool: "get_vat_info", why: "Check VAT registration before retrying invoice or VAT-sensitive postings." },
+    ];
+
+    switch (HttpClient.getResourceName(path)) {
+      case "purchase_invoices":
+        actions.push({ tool: "list_purchase_articles", why: "Verify purchase article and VAT article IDs." });
+        break;
+      case "sale_invoices":
+        actions.push({ tool: "list_sale_articles", why: "Verify sale article and VAT/account defaults." });
+        break;
+      case "transactions":
+        actions.push({ tool: "get_transaction", args: { id: HttpClient.getPathId(path) ?? "<transaction id>" }, why: "Inspect the transaction before retrying confirmation/update." });
+        break;
+    }
+
+    return actions;
+  }
+
+  private static recoveryActionsForConflict(path: string): Array<{ tool: string; args?: Record<string, unknown>; why: string }> {
+    const actions: Array<{ tool: string; args?: Record<string, unknown>; why: string }> = [];
+    switch (HttpClient.getResourceName(path)) {
+      case "purchase_invoices":
+        actions.push({
+          tool: "detect_duplicate_purchase_invoice",
+          args: { invoice_number: "<invoice number>", gross_price: "<gross price>", invoice_date: "<YYYY-MM-DD>" },
+          why: "Check whether the invoice already exists before retrying creation.",
+        });
+        break;
+      case "transactions":
+        actions.push({ tool: "reconcile_transactions", args: { min_confidence: 30 }, why: "Check whether the transaction is already matched or conflicts with another booking." });
+        break;
+    }
+    const listAction = HttpClient.listActionForPath(path);
+    if (listAction) actions.push(listAction);
+    return actions;
+  }
+
+  private static buildRecoveryAdvice(
+    status: number,
+    method: HttpMethod,
+    path: string,
+  ): { recovery_hint?: string; next_actions?: Array<{ tool: string; args?: Record<string, unknown>; why: string }> } {
+    switch (status) {
+      case 400:
+      case 422:
+        return {
+          recovery_hint:
+            "Validate the request body before retrying. Common causes are missing required fields, invalid date format, invoice total mismatches, inactive accounts, or missing account dimensions.",
+          next_actions: HttpClient.recoveryActionsForValidation(path),
+        };
+      case 401:
+        return {
+          recovery_hint:
+            "Check API credentials and the allowed public IP address. Restart the MCP server after changing stored credentials.",
+          next_actions: [
+            { tool: "get_setup_instructions", why: "Review the credential sources and import options for this working directory." },
+            { tool: "list_connections", why: "Verify which company connection is currently active." },
+          ],
+        };
+      case 403:
+        return {
+          recovery_hint:
+            "Check API token permissions, company access, and whether the active connection points to the intended company.",
+          next_actions: [
+            { tool: "list_connections", why: "Confirm the active company connection before retrying." },
+            { tool: "get_setup_instructions", why: "Review credential setup and storage scope." },
+          ],
+        };
+      case 404:
+        return {
+          recovery_hint:
+            "Verify that the referenced record still exists and is not deleted, voided, or in another company connection.",
+          next_actions: HttpClient.recoveryActionsForNotFound(path),
+        };
+      case 409:
+        return {
+          recovery_hint:
+            "Resolve the conflict before retrying. This often means a duplicate record, stale status, or an operation that must happen in a different order.",
+          next_actions: HttpClient.recoveryActionsForConflict(path),
+        };
+      case 429:
+        return {
+          recovery_hint:
+            "Wait before retrying. The upstream API is rate-limiting requests; reduce batch size or retry the same tool after a short delay.",
+        };
+      default:
+        return {};
+    }
   }
 
   private static isRetryableError(error: unknown): boolean {
@@ -192,7 +365,10 @@ export class HttpClient {
               `     Multiple IP addresses can be added, separated by ;`;
           }
 
-          throw new HttpError(errorMessage, response.status, method, path, { upstream_detail: upstreamDetail });
+          throw new HttpError(errorMessage, response.status, method, path, {
+            upstream_detail: upstreamDetail,
+            ...HttpClient.buildRecoveryAdvice(response.status, method, path),
+          });
         }
 
         if (response.status === 204) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { registerWiseImportTools } from "./tools/wise-import.js";
 import { registerCamtImportTools } from "./tools/camt-import.js";
 import { registerAccountingInboxTools } from "./tools/accounting-inbox.js";
 import { registerAnalyzeUnconfirmedTools } from "./tools/analyze-unconfirmed.js";
+import { registerWorkflowRecommendationTools } from "./tools/workflow-recommendations.js";
 import { registerResources } from "./resources/static-resources.js";
 import { registerDynamicResources } from "./resources/dynamic-resources.js";
 import { registerPrompts } from "./prompts.js";
@@ -999,6 +1000,7 @@ Reporting:
   registerCamtImportTools(scopedServer, api);
   registerAccountingInboxTools(scopedServer, api);
   registerAnalyzeUnconfirmedTools(scopedServer, api);
+  registerWorkflowRecommendationTools(scopedServer);
 
   // Register resources via scopedServer so reads stay pinned to the selected connection
   registerResources(scopedServer, api);

--- a/src/tool-response.ts
+++ b/src/tool-response.ts
@@ -1,0 +1,46 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { toMcpJson } from "./mcp-json.js";
+
+export interface ToolResponseEnvelopeOptions {
+  ok?: boolean;
+  action: string;
+  entity: string;
+  message: string;
+  raw?: unknown;
+  id?: string | number;
+  found?: boolean;
+  warnings?: unknown[];
+  next_actions?: unknown[];
+  extra?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function toolResponseEnvelope(options: ToolResponseEnvelopeOptions): Record<string, unknown> {
+  const rawFields = isRecord(options.raw) ? options.raw : {};
+
+  return {
+    ...rawFields,
+    ok: options.ok ?? true,
+    action: options.action,
+    entity: options.entity,
+    ...(options.id !== undefined ? { id: options.id } : {}),
+    ...(options.found !== undefined ? { found: options.found } : {}),
+    message: options.message,
+    ...(options.warnings !== undefined ? { warnings: options.warnings } : {}),
+    ...(options.next_actions !== undefined ? { next_actions: options.next_actions } : {}),
+    ...(options.extra ?? {}),
+    raw: options.raw,
+  };
+}
+
+export function toolResponse(options: ToolResponseEnvelopeOptions): CallToolResult {
+  return {
+    content: [{
+      type: "text",
+      text: toMcpJson(toolResponseEnvelope(options)),
+    }],
+  };
+}

--- a/src/tools/accounting-inbox.test.ts
+++ b/src/tools/accounting-inbox.test.ts
@@ -1806,6 +1806,107 @@ ${entryXml}
       }),
     ]));
     expect(payload.autopilot.next_recommended_action).toBeUndefined();
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      summary: expect.stringContaining("Ran"),
+      needs_decision: [],
+      needs_review: [],
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "import_camt053",
+        approval_required: true,
+        args: expect.objectContaining({
+          file_path: join(workspace, "statement.xml"),
+          accounts_dimensions_id: 101,
+          execute: true,
+        }),
+      },
+      approval_previews: [
+        expect.objectContaining({
+          title: "Approve CAMT transaction import",
+          execute_tool: "import_camt053",
+          execute_args: expect.objectContaining({ execute: true }),
+          accounting_impact: expect.arrayContaining([
+            expect.stringContaining("1 bank transaction"),
+          ]),
+          source_documents: [join(workspace, "statement.xml")],
+        }),
+      ],
+    });
+    expect(payload.workflow.available_actions[0]).toEqual(
+      expect.objectContaining({
+        kind: "approve_tool_call",
+        tool: "import_camt053",
+      }),
+    );
+  });
+
+  it("continue_accounting_workflow returns the next user-facing action from a previous inbox response", async () => {
+    const server = { registerTool: vi.fn() } as any;
+    registerAccountingInboxTools(server, {
+      clients: { findByCode: vi.fn().mockResolvedValue(undefined), findByName: vi.fn().mockResolvedValue([]), listAll: vi.fn().mockResolvedValue([]) },
+      journals: { listAllWithPostings: vi.fn().mockResolvedValue([]) },
+      products: {},
+      saleInvoices: { listAll: vi.fn().mockResolvedValue([]) },
+      purchaseInvoices: { listAll: vi.fn().mockResolvedValue([]) },
+      transactions: { listAll: vi.fn().mockResolvedValue([]) },
+      readonly: {
+        getBankAccounts: vi.fn().mockResolvedValue([]),
+        getAccountDimensions: vi.fn().mockResolvedValue([]),
+        getAccounts: vi.fn().mockResolvedValue([]),
+        getPurchaseArticles: vi.fn().mockResolvedValue([]),
+        getVatInfo: vi.fn().mockResolvedValue({ vat_number: "EE123456789" }),
+        getInvoiceInfo: vi.fn().mockResolvedValue({ invoice_company_name: "Seppo AI OÜ" }),
+      },
+    } as any);
+
+    const registration = server.registerTool.mock.calls.find(([name]: [string]) => name === "continue_accounting_workflow");
+    if (!registration) throw new Error("continue_accounting_workflow was not registered");
+    const continueHandler = registration[2] as (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+
+    const result = await continueHandler({
+      workflow_state_json: {
+        autopilot: {
+          user_summary: "Ran one dry run. One approval remains.",
+          done_automatically: ["CAMT dry run would create 1 transaction."],
+          needs_one_decision: [],
+          needs_accountant_review: [],
+          executed_steps: [{
+            step: 2,
+            tool: "import_camt053",
+            status: "completed",
+            purpose: "Preview CAMT import",
+            summary: "CAMT dry run would create 1 transaction, skip 0, raise 0 possible duplicate review item(s), and report 0 error(s).",
+            suggested_args: {
+              file_path: "/tmp/statement.xml",
+              accounts_dimensions_id: 101,
+              execute: false,
+            },
+            preview: {
+              created_count: 1,
+              skipped_count: 0,
+              possible_duplicate_count: 0,
+              error_count: 0,
+            },
+          }],
+        },
+      },
+    });
+    const payload = parseMcpResponse(result.content[0]!.text) as any;
+
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "import_camt053",
+        args: {
+          file_path: "/tmp/statement.xml",
+          accounts_dimensions_id: 101,
+          execute: true,
+        },
+      },
+    });
+    expect(payload.message).toContain("Next action");
   });
 
   it("cleanup_camt_possible_duplicate surfaces partial state when delete throws", async () => {

--- a/src/tools/accounting-inbox.ts
+++ b/src/tools/accounting-inbox.ts
@@ -8,7 +8,7 @@ import { batch, mutate, readOnly } from "../annotations.js";
 import { getAllowedRoots, isPathWithinRoot, resolveFilePath } from "../file-validation.js";
 import { logAudit } from "../audit-log.js";
 import type { AccountDimension, BankAccount, Transaction } from "../types/api.js";
-import { parseJsonObject, type ApiContext } from "./crud-tools.js";
+import { jsonObjectInput, parseJsonObject, type ApiContext } from "./crud-tools.js";
 import { DEFAULT_OTHER_FINANCIAL_EXPENSE_ACCOUNT } from "../accounting-defaults.js";
 import { registerCamtImportTools } from "./camt-import.js";
 import { registerWiseImportTools } from "./wise-import.js";
@@ -24,6 +24,7 @@ import {
   normalizeAutoBookingRuleMatch,
   saveAutoBookingRule,
 } from "../accounting-rules.js";
+import { workflowFromAccountingInboxPayload } from "../workflow-response.js";
 
 const MIN_AUTO_BOOKING_RULE_MATCH_LENGTH = 3;
 
@@ -1460,11 +1461,15 @@ export function registerAccountingInboxTools(server: McpServer, api: ApiContext)
         receipt_matching_dimension_id,
         wise_account_dimension_id,
       });
+      const payload = buildPreparedInboxPayload(prepared);
 
       return {
         content: [{
           type: "text",
-          text: toMcpJson(buildPreparedInboxPayload(prepared)),
+          text: toMcpJson({
+            ...payload,
+            workflow: workflowFromAccountingInboxPayload(payload),
+          }),
         }],
       };
     },
@@ -1598,11 +1603,48 @@ export function registerAccountingInboxTools(server: McpServer, api: ApiContext)
             : `No safe dry-run steps could be completed automatically yet. ${needsOneDecision.length} small decision(s) and ${needsAccountantReview.length} review item(s) remain.`,
         },
       };
+      const workflow = workflowFromAccountingInboxPayload(payload);
 
       return {
         content: [{
           type: "text",
-          text: toMcpJson(payload),
+          text: toMcpJson({
+            ...payload,
+            workflow,
+          }),
+        }],
+      };
+    },
+  );
+
+  registerTool(server,
+    "continue_accounting_workflow",
+    "Read a previous accounting inbox or workflow response and return the next user-facing action: one question, one review item, one approval card, or the next safe dry-run tool call.",
+    {
+      workflow_state_json: jsonObjectInput.describe("Previous response from prepare_accounting_inbox, run_accounting_inbox_dry_runs, continue_accounting_workflow, or an object containing a workflow field. Legacy callers may pass a JSON object string."),
+    },
+    { ...readOnly, title: "Continue Accounting Workflow" },
+    async ({ workflow_state_json }) => {
+      const workflowState = parseJsonObject(workflow_state_json, "workflow_state_json");
+      const workflow = isRecord(workflowState.workflow)
+        ? workflowState.workflow
+        : workflowFromAccountingInboxPayload(workflowState);
+      const nextAction = isRecord(workflow)
+        ? recordAt(workflow, "recommended_next_action")
+        : undefined;
+      const actionLabel = nextAction
+        ? stringAt(nextAction, "label") ?? stringAt(nextAction, "tool") ?? stringAt(nextAction, "kind")
+        : undefined;
+
+      return {
+        content: [{
+          type: "text",
+          text: toMcpJson({
+            message: actionLabel
+              ? `Next action: ${actionLabel}.`
+              : "Next action: no workflow action is currently pending.",
+            workflow,
+          }),
         }],
       };
     },
@@ -1612,7 +1654,7 @@ export function registerAccountingInboxTools(server: McpServer, api: ApiContext)
     "resolve_accounting_review_item",
     "Turn one accounting review item into a concrete next-step plan: default handling, unresolved questions, and the safest follow-up workflow or tool.",
     {
-      review_item_json: z.string().describe("JSON object from autopilot.needs_accountant_review[*].resolver_input or from a direct execution.needs_review / groups review item"),
+      review_item_json: jsonObjectInput.describe("Object from autopilot.needs_accountant_review[*].resolver_input or from a direct execution.needs_review / groups review item. Legacy callers may still pass a JSON object string."),
     },
     { ...readOnly, title: "Resolve Accounting Review Item" },
     async ({ review_item_json }) => {
@@ -1639,9 +1681,9 @@ export function registerAccountingInboxTools(server: McpServer, api: ApiContext)
     "prepare_accounting_review_action",
     "Prepare the concrete next action for one resolved accounting review item, such as deleting a duplicate transaction or saving a stable auto-booking rule.",
     {
-      review_item_json: z.string().describe("JSON object from autopilot.needs_accountant_review[*].resolver_input or a direct review item payload"),
+      review_item_json: jsonObjectInput.describe("Object from autopilot.needs_accountant_review[*].resolver_input or a direct review item payload. Legacy callers may still pass a JSON object string."),
       save_as_rule: z.boolean().optional().describe("When true, prefer preparing a save_auto_booking_rule action when the review item represents a stable recurring treatment."),
-      rule_override_json: z.string().optional().describe("Optional JSON object with explicit rule fields such as purchase_article_id, purchase_account_id, liability_account_id, vat_rate_dropdown, reversed_vat_id, reason, match, or category."),
+      rule_override_json: jsonObjectInput.optional().describe("Optional object with explicit rule fields such as purchase_article_id, purchase_account_id, liability_account_id, vat_rate_dropdown, reversed_vat_id, reason, match, or category. Legacy callers may still pass a JSON object string."),
     },
     { ...readOnly, title: "Prepare Accounting Review Action" },
     async ({ review_item_json, save_as_rule, rule_override_json }) => {

--- a/src/tools/camt-import-tools.test.ts
+++ b/src/tools/camt-import-tools.test.ts
@@ -188,6 +188,25 @@ describe("camt import tool", () => {
         counterparty: expect.stringMatching(wrapped("OpenAI, Inc.")),
       }),
     ]));
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "import_camt053",
+        args: {
+          file_path: "/tmp/camt.xml",
+          accounts_dimensions_id: 7,
+          execute: true,
+        },
+      },
+      approval_previews: [
+        expect.objectContaining({
+          title: "Approve CAMT transaction import",
+          accounting_impact: expect.arrayContaining(["1 bank transaction"]),
+          source_documents: ["/tmp/camt.xml"],
+        }),
+      ],
+    });
   });
 
   it("flags likely duplicates against older manual transactions in dry run", async () => {

--- a/src/tools/camt-import.ts
+++ b/src/tools/camt-import.ts
@@ -14,6 +14,7 @@ import { roundMoney } from "../money.js";
 import { reportProgress } from "../progress.js";
 import { isNonVoidTransaction } from "../transaction-status.js";
 import { normalizeCompanyName } from "../company-name.js";
+import { approvalPreviewsFromDryRunSteps, buildWorkflowEnvelope } from "../workflow-response.js";
 
 const CAMT_MAX_FILE_SIZE = 10 * 1024 * 1024;
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -1098,12 +1099,35 @@ export function registerCamtImportTools(server: McpServer, api: ApiContext): voi
           },
         })),
       }));
+      const workflowArgs = {
+        file_path,
+        accounts_dimensions_id,
+        ...(date_from ? { date_from } : {}),
+        ...(date_to ? { date_to } : {}),
+        execute: false,
+      };
+      const workflowSummary = dryRun
+        ? `CAMT dry run would create ${summary.created_count} bank transaction(s), skip ${summary.skipped_count}, flag ${summary.possible_duplicate_count} possible duplicate(s), and report ${summary.error_count} error(s).`
+        : `CAMT import created ${summary.created_count} bank transaction(s), skipped ${summary.skipped_count}, flagged ${summary.possible_duplicate_count} possible duplicate(s), and reported ${summary.error_count} error(s).`;
+      const workflow = buildWorkflowEnvelope({
+        summary: workflowSummary,
+        needs_review: sanitizedPossibleDuplicates,
+        approval_previews: dryRun
+          ? approvalPreviewsFromDryRunSteps([{
+              tool: "import_camt053",
+              summary: workflowSummary,
+              suggested_args: workflowArgs,
+              preview: summary,
+            }])
+          : [],
+      });
       return {
         content: [{
           type: "text",
           text: toMcpJson({
             mode,
             summary,
+            workflow,
             statement_metadata: sanitizedStatementMetadata,
             total_statement_entries: summary.total_statement_entries,
             eligible_entries: summary.eligible_entries,

--- a/src/tools/crud-tools.test.ts
+++ b/src/tools/crud-tools.test.ts
@@ -101,6 +101,10 @@ describe("parseJsonObject", () => {
     expect(parseJsonObject('{"name":"test"}', "data")).toEqual({ name: "test" });
   });
 
+  it("accepts an already-structured object", () => {
+    expect(parseJsonObject({ name: "test" }, "data")).toEqual({ name: "test" });
+  });
+
   it("throws on JSON array", () => {
     expect(() => parseJsonObject("[1,2]", "data")).toThrow('"data" must be a JSON object');
   });
@@ -114,6 +118,10 @@ describe("parseJsonObjectArray", () => {
   it("parses a valid JSON array of objects", () => {
     const result = parseJsonObjectArray('[{"a":1},{"b":2}]', "items");
     expect(result).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it("accepts an already-structured array of objects", () => {
+    expect(parseJsonObjectArray([{ a: 1 }, { b: 2 }], "items")).toEqual([{ a: 1 }, { b: 2 }]);
   });
 
   it("throws on non-array JSON", () => {
@@ -316,8 +324,104 @@ describe("create_product", () => {
       unit: "h",
     });
     expect(parseMcpResponse(result.content[0]!.text)).toMatchObject({
+      ok: true,
+      action: "created",
+      entity: "product",
+      id: 123,
       code: 0,
       created_object_id: 123,
+      raw: {
+        code: 0,
+        created_object_id: 123,
+      },
+    });
+  });
+});
+
+describe("structured JSON-compatible inputs", () => {
+  it("update_client accepts an object instead of a JSON string", async () => {
+    const { api, handler } = getCrudToolHarness("update_client", {
+      clients: { update: vi.fn().mockResolvedValue({ code: 1, messages: ["ok"] }) },
+    });
+
+    const result = await handler({ id: 7, data: { email: "new@example.com" } }) as { content: Array<{ text: string }> };
+
+    expect(api.clients.update).toHaveBeenCalledWith(7, { email: "new@example.com" });
+    expect(parseMcpResponse(result.content[0]!.text)).toMatchObject({
+      ok: true,
+      action: "updated",
+      entity: "client",
+      id: 7,
+    });
+  });
+
+  it("create_journal accepts an array of postings instead of a JSON string", async () => {
+    const { api, handler } = getCrudToolHarness("create_journal", {
+      readonly: {
+        getAccounts: vi.fn().mockResolvedValue([
+          { id: 4000, account_code: "4000", allows_dimensions: false, is_valid: true },
+        ]),
+        getAccountDimensions: vi.fn().mockResolvedValue([]),
+      },
+      journals: {
+        create: vi.fn().mockResolvedValue({ code: 0, messages: [], created_object_id: 456 }),
+      },
+    });
+
+    const result = await handler({
+      effective_date: "2026-04-24",
+      postings: [{ accounts_id: "4000", type: "D", amount: "12.50" }],
+    }) as { content: Array<{ text: string }> };
+
+    expect(api.journals.create).toHaveBeenCalledWith({
+      effective_date: "2026-04-24",
+      cl_currencies_id: "EUR",
+      postings: [{ accounts_id: 4000, type: "D", amount: 12.5 }],
+    });
+    expect(parseMcpResponse(result.content[0]!.text)).toMatchObject({
+      ok: true,
+      action: "created",
+      entity: "journal",
+      id: 456,
+    });
+  });
+
+  it("confirm_transaction accepts an array of distributions instead of a JSON string", async () => {
+    const { api, handler } = getCrudToolHarness("confirm_transaction", {
+      transactions: {
+        get: vi.fn().mockResolvedValue({ id: 1, clients_id: 99 }),
+        confirm: vi.fn().mockResolvedValue({ code: 0, messages: [] }),
+      },
+    });
+
+    await handler({
+      id: 1,
+      distributions: [{ related_table: "sale_invoices", related_id: "321", amount: "12" }],
+    });
+
+    expect(api.transactions.confirm).toHaveBeenCalledWith(1, [
+      { related_table: "sale_invoices", related_id: 321, amount: 12 },
+    ]);
+  });
+});
+
+describe("find_client_by_code", () => {
+  it("returns a structured not-found envelope instead of plain text", async () => {
+    const { handler } = getCrudToolHarness("find_client_by_code", {
+      clients: {
+        findByCode: vi.fn().mockResolvedValue(null),
+      },
+    });
+
+    const result = await handler({ code: "12345678" }) as { content: Array<{ text: string }> };
+
+    expect(parseMcpResponse(result.content[0]!.text)).toEqual({
+      ok: false,
+      action: "found",
+      entity: "client",
+      found: false,
+      message: "No client found for registry code 12345678.",
+      raw: null,
     });
   });
 });

--- a/src/tools/crud-tools.ts
+++ b/src/tools/crud-tools.ts
@@ -22,6 +22,7 @@ import { readOnly, create, mutate, destructive, send } from "../annotations.js";
 import { HttpError } from "../http-client.js";
 import { logAudit } from "../audit-log.js";
 import { DEFAULT_LIABILITY_ACCOUNT } from "../accounting-defaults.js";
+import { toolResponse } from "../tool-response.js";
 
 export interface ApiContext {
   clients: ClientsApi;
@@ -56,16 +57,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function parseJsonObject(input: string, label: string): Record<string, unknown> {
-  const parsed = safeJsonParse(input, label);
+export function parseJsonObject(input: unknown, label: string): Record<string, unknown> {
+  const parsed = typeof input === "string" ? safeJsonParse(input, label) : input;
   if (!isRecord(parsed)) {
     throw new Error(`"${label}" must be a JSON object`);
   }
   return parsed;
 }
 
-export function parseJsonObjectArray(input: string, label: string): Record<string, unknown>[] {
-  const parsed = safeJsonParse(input, label);
+export function parseJsonObjectArray(input: unknown, label: string): Record<string, unknown>[] {
+  const parsed = typeof input === "string" ? safeJsonParse(input, label) : input;
   if (!Array.isArray(parsed)) {
     throw new Error(`"${label}" must be a JSON array`);
   }
@@ -127,7 +128,7 @@ export function requireNumericFields(items: Record<string, unknown>[], label: st
   });
 }
 
-function parsePostings(input: string): Posting[] {
+function parsePostings(input: unknown): Posting[] {
   const postings = parseJsonObjectArray(input, "postings");
   requireFields(postings, "postings", ["accounts_id", "type", "amount"]);
   requireNumericFields(postings, "postings", [
@@ -145,7 +146,7 @@ function parsePostings(input: string): Posting[] {
   return postings as unknown as Posting[];
 }
 
-function parseTransactionDistributions(input: string): TransactionDistribution[] {
+function parseTransactionDistributions(input: unknown): TransactionDistribution[] {
   const distributions = parseJsonObjectArray(input, "distributions");
   requireFields(distributions, "distributions", ["related_table", "amount"]);
   requireNumericFields(distributions, "distributions", ["amount", "related_id", "related_sub_id"]);
@@ -172,7 +173,7 @@ function parseTransactionDistributions(input: string): TransactionDistribution[]
   return distributions as unknown as TransactionDistribution[];
 }
 
-export function parseSaleInvoiceItems(input: string): SaleInvoiceItem[] {
+export function parseSaleInvoiceItems(input: unknown): SaleInvoiceItem[] {
   const items = parseJsonObjectArray(input, "items");
   requireFields(items, "items", ["products_id", "custom_title", "amount"]);
   requireNumericFields(items, "items", [
@@ -185,7 +186,7 @@ export function parseSaleInvoiceItems(input: string): SaleInvoiceItem[] {
   return items as unknown as SaleInvoiceItem[];
 }
 
-export function parsePurchaseInvoiceItems(input: string): PurchaseInvoiceItem[] {
+export function parsePurchaseInvoiceItems(input: unknown): PurchaseInvoiceItem[] {
   const items = parseJsonObjectArray(input, "items");
   requireFields(items, "items", ["cl_purchase_articles_id", "custom_title"]);
   requireNumericFields(items, "items", [
@@ -204,6 +205,19 @@ const pageParam = z.object({
 
 export const coerceId = z.coerce.number().int().positive();
 const idParam = z.object({ id: coerceId.describe("Object ID") });
+export const jsonObjectInput = z.union([
+  z.record(z.unknown()),
+  z.string(),
+]);
+export const jsonObjectArrayInput = z.union([
+  z.array(z.record(z.unknown())),
+  z.string(),
+]);
+export const jsonObjectOrArrayInput = z.union([
+  z.record(z.unknown()),
+  z.array(z.record(z.unknown())),
+  z.string(),
+]);
 
 const MCP_TAG = "e-arveldaja-mcp";
 
@@ -356,7 +370,7 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
 
   registerTool(server, "update_client", "Update an existing client. Server-managed fields (id, is_active, deactivated_date) are rejected — use the dedicated deactivate/restore tools.", {
     id: coerceId.describe("Client ID"),
-    data: z.string().describe("JSON object with fields to update"),
+    data: jsonObjectInput.describe("Object with fields to update. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Client" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const updateErrors = validateUpdateFields(parsed, "client");
@@ -369,7 +383,13 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
       summary: `Updated client ${id}`,
       details: { fields_changed: Object.keys(parsed) },
     });
-    return { content: [{ type: "text", text: toMcpJson(result) }] };
+    return toolResponse({
+      action: "updated",
+      entity: "client",
+      id,
+      message: `Updated client ${id}.`,
+      raw: result,
+    });
   });
 
   registerTool(server, "deactivate_client", "Deactivate a client (can be restored with restore_client)", idParam.shape, { ...mutate, title: "Deactivate Client" }, async ({ id }) => {
@@ -403,7 +423,23 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
     code: z.string().describe("Business registry code or personal ID"),
   }, { ...readOnly, title: "Find Client by Registry Code" }, async ({ code }) => {
     const result = await api.clients.findByCode(code);
-    return { content: [{ type: "text", text: result ? toMcpJson(result) : "Not found" }] };
+    return result
+      ? toolResponse({
+        action: "found",
+        entity: "client",
+        id: result.id,
+        found: true,
+        message: `Found client for registry code ${code}.`,
+        raw: result,
+      })
+      : toolResponse({
+        ok: false,
+        action: "found",
+        entity: "client",
+        found: false,
+        message: `No client found for registry code ${code}.`,
+        raw: null,
+      });
   });
 
   // =====================
@@ -440,12 +476,18 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
       summary: `Created product "${params.name}" (${params.code})`,
       details: { name: params.name, code: params.code, sales_price: params.sales_price },
     });
-    return { content: [{ type: "text", text: toMcpJson(result) }] };
+    return toolResponse({
+      action: "created",
+      entity: "product",
+      id: result.created_object_id,
+      message: `Created product "${params.name}" (${params.code}).`,
+      raw: result,
+    });
   });
 
   registerTool(server, "update_product", "Update a product. Server-managed fields (id, is_active, deactivated_date) are rejected — use the dedicated deactivate/restore tools.", {
     id: coerceId.describe("Product ID"),
-    data: z.string().describe("JSON object with fields to update"),
+    data: jsonObjectInput.describe("Object with fields to update. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Product" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const updateErrors = validateUpdateFields(parsed, "product");
@@ -563,8 +605,8 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
     clients_id: z.number().optional().describe("Related client ID"),
     document_number: z.string().optional().describe("Document number"),
     cl_currencies_id: z.string().optional().describe("Currency (default EUR)"),
-    postings: z.string().describe(
-      "JSON array of postings: [{accounts_id, type: 'D'|'C', amount, accounts_dimensions_id?, base_amount?, projects_project_id?, projects_location_id?, projects_person_id?}]. " +
+    postings: jsonObjectArrayInput.describe(
+      "Array of postings: [{accounts_id, type: 'D'|'C', amount, accounts_dimensions_id?, base_amount?, projects_project_id?, projects_location_id?, projects_person_id?}]. Legacy callers may still pass a JSON array string. " +
       "accounts_dimensions_id is REQUIRED when accounts_id refers to an account with sub-accounts (use list_account_dimensions to look it up). " +
       "base_amount is the EUR equivalent for multi-currency entries (when cl_currencies_id is not EUR). " +
       "projects_project_id / projects_location_id / projects_person_id link the posting to project tracking dimensions."
@@ -603,12 +645,18 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
         })),
       },
     });
-    return { content: [{ type: "text", text: toMcpJson(result) }] };
+    return toolResponse({
+      action: "created",
+      entity: "journal",
+      id: result.created_object_id,
+      message: `Created journal${params.title ? ` "${params.title}"` : ""} on ${params.effective_date}.`,
+      raw: result,
+    });
   });
 
   registerTool(server, "update_journal", "Update a journal entry. Server-managed fields (id, registered, register_date, status) are rejected — use the dedicated confirm/invalidate tools. Once the journal is registered, effective_date is audit-locked; invalidate_journal first to edit it.", {
     id: coerceId.describe("Journal ID"),
-    data: z.string().describe("JSON object with fields to update"),
+    data: jsonObjectInput.describe("Object with fields to update. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Journal" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const current = await api.journals.get(id);
@@ -856,8 +904,8 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
     "For invoice distributions, clients_id is auto-resolved from the invoice.",
     {
     id: coerceId.describe("Transaction ID"),
-    distributions: z.string().optional().describe(
-      "JSON array of distribution rows: [{related_table, related_id, related_sub_id?, amount}]. " +
+      distributions: jsonObjectArrayInput.optional().describe(
+        "Array of distribution rows: [{related_table, related_id, related_sub_id?, amount}]. Legacy callers may still pass a JSON array string. " +
       "related_table values: 'accounts' (book to a GL account), 'purchase_invoices', 'sale_invoices'. " +
       "related_id is REQUIRED for all three related_table values (the account ID, purchase-invoice ID, or sale-invoice ID). " +
       "related_sub_id is REQUIRED when related_table='accounts' and the account has dimensions — " +
@@ -909,7 +957,7 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
 
   registerTool(server, "update_transaction", "Update transaction metadata fields such as bank reference, counterparty name, bank account number, description, or payment reference.", {
     id: coerceId.describe("Transaction ID"),
-    data: z.string().describe("JSON object with allowed metadata fields only: bank_ref_number, bank_account_name, bank_account_no, description, ref_number"),
+    data: jsonObjectInput.describe("Object with allowed metadata fields only: bank_ref_number, bank_account_name, bank_account_no, description, ref_number. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Transaction" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const validationErrors = validateTransactionUpdateData(parsed);
@@ -1067,8 +1115,8 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
     cl_countries_id: z.string().optional().describe("Country (default EST)"),
     sale_invoice_type: z.string().optional().describe("Type: INVOICE or CREDIT_INVOICE"),
     show_client_balance: z.boolean().optional().describe("Show client balance on invoice"),
-    items: z.string().describe(
-      "JSON array of invoice items: [{products_id, custom_title, amount, unit_net_price, sale_accounts_id?, sale_accounts_dimensions_id?, vat_accounts_id?, cl_sale_articles_id?, discount_percent?, projects_project_id?, projects_location_id?, projects_person_id?}]. " +
+      items: jsonObjectArrayInput.describe(
+        "Array of invoice items: [{products_id, custom_title, amount, unit_net_price, sale_accounts_id?, sale_accounts_dimensions_id?, vat_accounts_id?, cl_sale_articles_id?, discount_percent?, projects_project_id?, projects_location_id?, projects_person_id?}]. Legacy callers may still pass a JSON array string. " +
       "sale_accounts_dimensions_id is REQUIRED when the revenue account has dimensions (sub-accounts). Use list_account_dimensions to look up dimension IDs. " +
       "Note: SaleInvoicesItems schema has no vat_accounts_dimensions_id field — only the purchase side does."
     ),
@@ -1104,7 +1152,7 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
 
   registerTool(server, "update_sale_invoice", "Update a sales invoice. Server-managed fields (id, status, registered, register_date) are rejected — use the dedicated confirm/invalidate tools. Once CONFIRMED, create_date and journal_date are audit-locked; invalidate_sale_invoice first to edit them.", {
     id: coerceId.describe("Invoice ID"),
-    data: z.string().describe("JSON with fields to update"),
+    data: jsonObjectInput.describe("Object with fields to update. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Sale Invoice" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const current = await api.saleInvoices.get(id);
@@ -1207,8 +1255,8 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
       gross_price: z.number().describe("Total gross amount from original invoice (EXACT, for payment matching). Required — confirm_purchase_invoice fails without it."),
       cl_currencies_id: z.string().optional().describe("Currency (default EUR)"),
       liability_accounts_id: z.number().optional().describe("Liability account (default 2310)"),
-      items: z.string().describe(
-        "JSON array of items: [{custom_title, cl_purchase_articles_id, purchase_accounts_id, purchase_accounts_dimensions_id?, total_net_price, amount, vat_rate_dropdown?, vat_accounts_id?, vat_accounts_dimensions_id?, cl_vat_articles_id?, project_no_vat_gross_price?, cl_fringe_benefits_id?}]. " +
+      items: jsonObjectArrayInput.describe(
+        "Array of items: [{custom_title, cl_purchase_articles_id, purchase_accounts_id, purchase_accounts_dimensions_id?, total_net_price, amount, vat_rate_dropdown?, vat_accounts_id?, vat_accounts_dimensions_id?, cl_vat_articles_id?, project_no_vat_gross_price?, cl_fringe_benefits_id?}]. Legacy callers may still pass a JSON array string. " +
         "purchase_accounts_dimensions_id is REQUIRED when the expense account has dimensions (sub-accounts). Same rule applies to vat_accounts_dimensions_id when the VAT account has dimensions. Use list_account_dimensions to look up dimension IDs."
       ),
       notes: z.string().optional().describe("Notes"),
@@ -1265,7 +1313,7 @@ export function registerCrudTools(server: McpServer, api: ApiContext): void {
 
   registerTool(server, "update_purchase_invoice", "Update a purchase invoice. Server-managed fields (id, status, registered, register_date, payment_status) are rejected — use the dedicated confirm/invalidate tools. Once CONFIRMED, create_date and journal_date are audit-locked; invalidate_purchase_invoice first to edit them.", {
     id: coerceId.describe("Invoice ID"),
-    data: z.string().describe("JSON with fields to update"),
+    data: jsonObjectInput.describe("Object with fields to update. Legacy callers may still pass a JSON object string."),
   }, { ...mutate, title: "Update Purchase Invoice" }, async ({ id, data }) => {
     const parsed = parseJsonObject(data, "data");
     const current = await api.purchaseInvoices.get(id);

--- a/src/tools/pdf-workflow.ts
+++ b/src/tools/pdf-workflow.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readFile } from "fs/promises";
 import { registerTool } from "../mcp-compat.js";
 import { toMcpJson, wrapUntrustedOcr } from "../mcp-json.js";
-import { type ApiContext, isCompanyVatRegistered, parsePurchaseInvoiceItems, safeJsonParse, coerceId, tagNotes } from "./crud-tools.js";
+import { type ApiContext, isCompanyVatRegistered, parseJsonObjectArray, parsePurchaseInvoiceItems, jsonObjectArrayInput, coerceId, tagNotes } from "./crud-tools.js";
 import type { PurchaseInvoice, CreatePurchaseInvoiceData } from "../types/api.js";
 import { InvoiceCreationError } from "../api/purchase-invoices.api.js";
 import { resolveFileInput } from "../file-validation.js";
@@ -139,7 +139,7 @@ export function registerPdfWorkflowTools(server: McpServer, api: ApiContext): vo
       total_net: z.number().describe("Invoice total net amount"),
       total_vat: z.number().describe("Invoice total VAT amount"),
       total_gross: z.number().describe("Invoice total gross amount"),
-      items: z.string().describe("JSON array of items with at least {total_net_price, vat_rate_dropdown?} each"),
+      items: jsonObjectArrayInput.describe("Array of items with at least {total_net_price, vat_rate_dropdown?} each. Legacy callers may still pass a JSON array string."),
       invoice_date: z.string().optional().describe("Invoice date (YYYY-MM-DD)"),
       due_date: z.string().optional().describe("Due date (YYYY-MM-DD)"),
     },
@@ -147,7 +147,7 @@ export function registerPdfWorkflowTools(server: McpServer, api: ApiContext): vo
     async ({ total_net, total_vat, total_gross, items, invoice_date, due_date }) => {
       const errors: string[] = [];
       const warnings: string[] = [];
-      const parsed = safeJsonParse(items, "items");
+      const parsed = parseJsonObjectArray(items, "items");
       if (!Array.isArray(parsed)) {
         return {
           content: [{
@@ -438,8 +438,8 @@ export function registerPdfWorkflowTools(server: McpServer, api: ApiContext): vo
       invoice_date: z.string().describe("Invoice date (YYYY-MM-DD)"),
       journal_date: z.string().describe("Turnover/booking date (YYYY-MM-DD)"),
       term_days: z.number().describe("Payment term days"),
-      items: z.string().describe(
-        "JSON array of items: [{custom_title, cl_purchase_articles_id, purchase_accounts_id, purchase_accounts_dimensions_id?, total_net_price, vat_rate_dropdown?, amount?, vat_accounts_id?, vat_accounts_dimensions_id?, cl_vat_articles_id?, reversed_vat_id?}]. " +
+      items: jsonObjectArrayInput.describe(
+        "Array of items: [{custom_title, cl_purchase_articles_id, purchase_accounts_id, purchase_accounts_dimensions_id?, total_net_price, vat_rate_dropdown?, amount?, vat_accounts_id?, vat_accounts_dimensions_id?, cl_vat_articles_id?, reversed_vat_id?}]. Legacy callers may still pass a JSON array string. " +
         "purchase_accounts_dimensions_id is REQUIRED when the expense account has dimensions (sub-accounts). Same rule applies to vat_accounts_dimensions_id when the VAT account has dimensions. Use list_account_dimensions to look up dimension IDs."
       ),
       vat_price: z.number().optional().describe("EXACT total VAT from the original invoice. Optional because OCR may not extract reliably; pass when known."),

--- a/src/tools/receipt-batch-failure.test.ts
+++ b/src/tools/receipt-batch-failure.test.ts
@@ -204,6 +204,25 @@ describe("process_receipt_batch rollback handling", () => {
         vat_rate_dropdown: "-",
       },
     });
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "process_receipt_batch",
+        args: {
+          folder_path: "/tmp/receipts",
+          accounts_dimensions_id: 100,
+          execute: true,
+        },
+      },
+      approval_previews: [
+        expect.objectContaining({
+          title: "Approve receipt batch booking",
+          accounting_impact: expect.arrayContaining(["1 purchase invoice"]),
+          source_documents: ["/tmp/receipts"],
+        }),
+      ],
+    });
 
     rmSync(rulesDir, { recursive: true, force: true });
   });

--- a/src/tools/receipt-inbox-tools.test.ts
+++ b/src/tools/receipt-inbox-tools.test.ts
@@ -547,6 +547,107 @@ describe("receipt inbox tool status handling", () => {
     expect(api.transactions.confirm).not.toHaveBeenCalled();
   });
 
+  it("apply_transaction_classifications returns an approval workflow for dry-run bookings", async () => {
+    const { handler, api } = setupReceiptTool("apply_transaction_classifications", {
+      clients: [
+        {
+          id: 7,
+          name: "OpenAI Ireland Limited",
+          is_supplier: true,
+          is_client: false,
+          cl_code_country: "IE",
+          is_member: false,
+          send_invoice_to_email: false,
+          send_invoice_to_accounting_email: false,
+          is_deleted: false,
+        },
+      ],
+      transactionDetails: {
+        44: {
+          id: 44,
+          status: "PROJECT",
+          is_deleted: false,
+          type: "C",
+          amount: 25,
+          date: "2026-03-22",
+          accounts_dimensions_id: 100,
+          bank_account_name: "LHV Bank",
+          description: "Bank monthly fee",
+          cl_currencies_id: "EUR",
+        },
+      },
+      purchaseArticles: [{
+        id: 501,
+        name_est: "Bank fee",
+        name_eng: "Bank fee",
+        accounts_id: 5230,
+        vat_accounts_id: 1510,
+        cl_vat_articles_id: 1,
+        is_disabled: false,
+        priority: 1,
+      }],
+      accounts: [{
+        id: 5230,
+        name_est: "Bank fees",
+        name_eng: "Bank fees",
+        account_type_est: "Kulud",
+        account_type_eng: "Expenses",
+      }],
+    });
+
+    const classificationsJson = JSON.stringify([{
+      category: "bank_fees",
+      apply_mode: "purchase_invoice",
+      normalized_counterparty: "lhv bank",
+      display_counterparty: "LHV Bank",
+      recurring: true,
+      similar_amounts: true,
+      total_amount: 25,
+      suggested_booking: {
+        purchase_article_id: 501,
+        purchase_article_name: "Bank fee",
+        purchase_account_id: 5230,
+        purchase_account_name: "Bank fees",
+        liability_account_id: 2310,
+        reason: "Bank service fee",
+      },
+      reasons: ["keyword"],
+      transactions: [{
+        id: 44,
+        type: "C",
+        amount: 25,
+        date: "2026-03-22",
+        description: "Bank monthly fee",
+        bank_account_name: "LHV Bank",
+        accounts_dimensions_id: 100,
+      }],
+    }]);
+
+    const result = await handler({ classifications_json: classificationsJson });
+    const payload = parseMcpResponse(result.content[0]!.text);
+
+    expect(payload.summary.dry_run_preview).toBe(1);
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "apply_transaction_classifications",
+        args: {
+          classifications_json: classificationsJson,
+          execute: true,
+        },
+      },
+      approval_previews: [
+        expect.objectContaining({
+          title: "Approve transaction classification booking",
+          accounting_impact: expect.arrayContaining(["1 purchase invoice"]),
+        }),
+      ],
+    });
+    expect(api.purchaseInvoices.createAndSetTotals).not.toHaveBeenCalled();
+    expect(api.transactions.confirm).not.toHaveBeenCalled();
+  });
+
   it("apply_transaction_classifications invalidates the draft invoice if the transaction turns VOID after creation", async () => {
     const getImpl = vi.fn()
       .mockResolvedValueOnce({

--- a/src/tools/receipt-inbox.ts
+++ b/src/tools/receipt-inbox.ts
@@ -12,7 +12,7 @@ import { readOnly, batch } from "../annotations.js";
 import { logAudit } from "../audit-log.js";
 import { buildBatchExecutionContract } from "../batch-execution.js";
 import { isProjectTransaction } from "../transaction-status.js";
-import { type ApiContext, isCompanyVatRegistered, safeJsonParse, coerceId, tagNotes } from "./crud-tools.js";
+import { type ApiContext, isCompanyVatRegistered, jsonObjectOrArrayInput, safeJsonParse, coerceId, tagNotes } from "./crud-tools.js";
 import { applyPurchaseVatDefaults, getPurchaseArticlesWithVat } from "./purchase-vat-defaults.js";
 import { parseDocument } from "../document-parser.js";
 import {
@@ -58,6 +58,7 @@ import {
   buildClassificationReviewGuidance,
   buildReceiptReviewGuidance,
 } from "../estonian-accounting-guidance.js";
+import { approvalPreviewsFromDryRunSteps, buildWorkflowEnvelope } from "../workflow-response.js";
 
 const MAX_RECEIPT_SIZE = 50 * 1024 * 1024; // 50 MB
 const FILE_TYPE_EXTENSIONS = {
@@ -1585,6 +1586,28 @@ export function registerReceiptInboxTools(server: McpServer, api: ApiContext): v
       };
       const mode = dryRun ? "DRY_RUN" : "EXECUTED";
       const sanitizedResults = results.map(sanitizeReceiptResultForOutput);
+      const workflowArgs = {
+        folder_path,
+        accounts_dimensions_id,
+        ...(date_from ? { date_from } : {}),
+        ...(date_to ? { date_to } : {}),
+        execute: false,
+      };
+      const workflowSummary = dryRun
+        ? `Receipt dry run would create ${summary.dry_run_preview} purchase invoice(s), match ${summary.matched}, skip ${summary.skipped_duplicate} duplicate(s), leave ${summary.needs_review} in review, and fail ${summary.failed}.`
+        : `Receipt batch created ${summary.created} purchase invoice(s), matched ${summary.matched}, skipped ${summary.skipped_duplicate} duplicate(s), left ${summary.needs_review} in review, and failed ${summary.failed}.`;
+      const workflow = buildWorkflowEnvelope({
+        summary: workflowSummary,
+        needs_review: sanitizedResults.filter(result => result.status === "needs_review"),
+        approval_previews: dryRun
+          ? approvalPreviewsFromDryRunSteps([{
+              tool: "process_receipt_batch",
+              summary: workflowSummary,
+              suggested_args: workflowArgs,
+              preview: summary,
+            }])
+          : [],
+      });
 
       return {
         content: [{
@@ -1594,6 +1617,7 @@ export function registerReceiptInboxTools(server: McpServer, api: ApiContext): v
             folder_path: scan.folder_path,
             accounts_dimensions_id,
             summary,
+            workflow,
             skipped: scan.skipped,
             results: sanitizedResults,
             execution: buildBatchExecutionContract({
@@ -1722,13 +1746,15 @@ export function registerReceiptInboxTools(server: McpServer, api: ApiContext): v
     "apply_transaction_classifications",
     "Apply the output of classify_unmatched_transactions. DRY RUN by default. Only expense-like categories are auto-booked as purchase invoices; review-only categories are reported back.",
     {
-      classifications_json: z.string().describe("JSON from classify_unmatched_transactions"),
+      classifications_json: jsonObjectOrArrayInput.describe("Structured output from classify_unmatched_transactions. Legacy callers may still pass a JSON string."),
       execute: z.boolean().optional().describe("Actually create invoices and link transactions (default false = dry run)"),
     },
     { ...batch, title: "Apply Transaction Classifications" },
     async ({ classifications_json, execute }) => {
       const dryRun = execute !== true;
-      const parsed = safeJsonParse(classifications_json, "classifications_json");
+      const parsed = typeof classifications_json === "string"
+        ? safeJsonParse(classifications_json, "classifications_json")
+        : classifications_json;
       const groups = extractClassificationGroups(parsed);
 
       const [clients, purchaseArticlesWithVat, purchaseInvoices, accounts] = await Promise.all([
@@ -1997,6 +2023,24 @@ export function registerReceiptInboxTools(server: McpServer, api: ApiContext): v
         failed: results.filter(result => result.status === "failed").length,
       };
       const mode = dryRun ? "DRY_RUN" : "EXECUTED";
+      const workflowArgs = {
+        classifications_json,
+        execute: false,
+      };
+      const workflowSummary = dryRun
+        ? `Classification dry run would create ${summary.dry_run_preview} purchase invoice group(s), skip ${summary.skipped}, and fail ${summary.failed}.`
+        : `Applied ${summary.applied} classification group(s), skipped ${summary.skipped}, and failed ${summary.failed}.`;
+      const workflow = buildWorkflowEnvelope({
+        summary: workflowSummary,
+        approval_previews: dryRun
+          ? approvalPreviewsFromDryRunSteps([{
+              tool: "apply_transaction_classifications",
+              summary: workflowSummary,
+              suggested_args: workflowArgs,
+              preview: summary,
+            }])
+          : [],
+      });
 
       return {
         content: [{
@@ -2005,6 +2049,7 @@ export function registerReceiptInboxTools(server: McpServer, api: ApiContext): v
             mode,
             dry_run: dryRun,
             summary,
+            workflow,
             results,
             execution: buildBatchExecutionContract({
               mode,

--- a/src/tools/wise-import.test.ts
+++ b/src/tools/wise-import.test.ts
@@ -955,6 +955,26 @@ describe("wise import tool", () => {
         status: "would_create",
       }),
     ]));
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "approve_tool_call",
+        tool: "import_wise_transactions",
+        args: {
+          file_path: "/tmp/wise.csv",
+          accounts_dimensions_id: 5,
+          inter_account_dimension_id: 20,
+          execute: true,
+        },
+      },
+      approval_previews: [
+        expect.objectContaining({
+          title: "Approve Wise transaction import",
+          accounting_impact: expect.arrayContaining(["1 bank transaction"]),
+          source_documents: ["/tmp/wise.csv"],
+        }),
+      ],
+    });
     expect(api.transactions.confirm).not.toHaveBeenCalled();
     expect(api.journals.listAllWithPostings).not.toHaveBeenCalled();
   });

--- a/src/tools/wise-import.ts
+++ b/src/tools/wise-import.ts
@@ -16,6 +16,7 @@ import { roundMoney } from "../money.js";
 import { normalizeCompanyName } from "../company-name.js";
 import { buildInterAccountJournalIndex, findMatchingJournal } from "./inter-account-utils.js";
 import { DEFAULT_OTHER_FINANCIAL_EXPENSE_ACCOUNT } from "../accounting-defaults.js";
+import { approvalPreviewsFromDryRunSteps, buildWorkflowEnvelope } from "../workflow-response.js";
 
 interface WiseRow {
   id: string;
@@ -844,6 +845,32 @@ export function registerWiseImportTools(server: McpServer, api: ApiContext): voi
       }));
       const sanitizedExecutionSkipped = executionSkipped.map(sanitizeReason);
       const sanitizedExecutionErrors = executionErrors.map(sanitizeReason);
+      const workflowArgs = {
+        file_path,
+        accounts_dimensions_id,
+        ...(feeAccountDimensionsId !== undefined ? { fee_account_dimensions_id: feeAccountDimensionsId } : {}),
+        ...((inter_account_dimension_id ?? autoDetectedInterAccountDimId) !== undefined
+          ? { inter_account_dimension_id: inter_account_dimension_id ?? autoDetectedInterAccountDimId }
+          : {}),
+        ...(date_from ? { date_from } : {}),
+        ...(date_to ? { date_to } : {}),
+        ...(skip_jar_transfers !== undefined ? { skip_jar_transfers } : {}),
+        execute: false,
+      };
+      const workflowSummary = dryRun
+        ? `Wise dry run would create ${summary.created} bank transaction(s), skip ${summary.skipped}, and report ${summary.error_count} error(s).`
+        : `Wise import created ${summary.created} bank transaction(s), skipped ${summary.skipped}, and reported ${summary.error_count} error(s).`;
+      const workflow = buildWorkflowEnvelope({
+        summary: workflowSummary,
+        approval_previews: dryRun
+          ? approvalPreviewsFromDryRunSteps([{
+              tool: "import_wise_transactions",
+              summary: workflowSummary,
+              suggested_args: workflowArgs,
+              preview: summary,
+            }])
+          : [],
+      });
 
       return {
         content: [{
@@ -851,6 +878,7 @@ export function registerWiseImportTools(server: McpServer, api: ApiContext): voi
           text: toMcpJson({
             mode,
             summary,
+            workflow,
             total_csv_rows: summary.total_csv_rows,
             eligible: summary.eligible,
             filtered_out: summary.filtered_out,

--- a/src/tools/workflow-recommendations.test.ts
+++ b/src/tools/workflow-recommendations.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseMcpResponse } from "../mcp-json.js";
+import { registerWorkflowRecommendationTools } from "./workflow-recommendations.js";
+
+function getRecommendWorkflowHarness() {
+  const server = { registerTool: vi.fn() };
+  registerWorkflowRecommendationTools(server as never);
+  const call = server.registerTool.mock.calls.find(([name]) => name === "recommend_workflow");
+  if (!call) throw new Error("recommend_workflow tool was not registered");
+  return {
+    options: call[1] as { inputSchema?: Record<string, unknown> },
+    handler: call[2] as (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>,
+  };
+}
+
+describe("recommend_workflow", () => {
+  it("registers a discoverability tool with a structured goal input", () => {
+    const { options } = getRecommendWorkflowHarness();
+
+    expect(options.inputSchema).toHaveProperty("goal");
+    expect(options.inputSchema).toHaveProperty("risk_tolerance");
+  });
+
+  it("recommends the CAMT import workflow for bank statement goals", async () => {
+    const { handler } = getRecommendWorkflowHarness();
+
+    const result = await handler({ goal: "import bank statement CAMT file", risk_tolerance: "balanced" });
+    const payload = parseMcpResponse(result.content[0]!.text) as Record<string, any>;
+
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "recommended",
+      entity: "workflow",
+      recommended_workflow: {
+        id: "import-camt",
+        prompt: "import-camt",
+      },
+      risk_policy: {
+        default_mode: "dry_run",
+      },
+    });
+    expect(payload.next_actions[0]).toMatchObject({
+      tool: "import_camt053",
+      args: { execute: false },
+    });
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      summary: expect.stringContaining("Recommended Import CAMT Bank Statement"),
+      needs_decision: [],
+      needs_review: [],
+      recommended_next_action: {
+        kind: "tool_call",
+        tool: "import_camt053",
+        approval_required: false,
+      },
+    });
+    expect(payload.workflow.available_actions[0]).toMatchObject({
+      kind: "tool_call",
+      tool: "import_camt053",
+    });
+  });
+
+  it("returns a compact catalog when no goal is provided", async () => {
+    const { handler } = getRecommendWorkflowHarness();
+
+    const result = await handler({});
+    const payload = parseMcpResponse(result.content[0]!.text) as Record<string, any>;
+
+    expect(payload.ok).toBe(true);
+    expect(payload.available_workflows.map((workflow: any) => workflow.id)).toEqual(
+      expect.arrayContaining(["accounting-inbox", "book-invoice", "import-wise", "reconcile-bank"]),
+    );
+    expect(payload.workflow).toMatchObject({
+      contract: "workflow_action_v1",
+      recommended_next_action: {
+        kind: "answer_question",
+        question: "What accounting task should be handled next?",
+      },
+    });
+    expect(payload.workflow.recommended_next_action.tool).toBeUndefined();
+    expect(JSON.stringify(payload.workflow)).not.toContain("<describe the user's accounting goal>");
+  });
+
+  it("recommends the registered apply transaction classifications tool for receipt batches", async () => {
+    const { handler } = getRecommendWorkflowHarness();
+
+    const result = await handler({ goal: "process a folder of receipts and classify expenses" });
+    const payload = parseMcpResponse(result.content[0]!.text) as Record<string, any>;
+
+    expect(payload.raw.primary_tools).toContain("apply_transaction_classifications");
+    expect(payload.raw.primary_tools).not.toContain("apply_unmatched_transaction_classifications");
+  });
+});

--- a/src/tools/workflow-recommendations.ts
+++ b/src/tools/workflow-recommendations.ts
@@ -1,0 +1,246 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { readOnly } from "../annotations.js";
+import { registerTool } from "../mcp-compat.js";
+import { toolResponse } from "../tool-response.js";
+import { buildWorkflowEnvelope } from "../workflow-response.js";
+
+type RiskMode = "automatic" | "confirm_once" | "dry_run" | "accountant_review";
+
+interface WorkflowGuide {
+  id: string;
+  prompt: string;
+  title: string;
+  summary: string;
+  when_to_use: string[];
+  primary_tools: string[];
+  risk_policy: {
+    default_mode: RiskMode;
+    interrupt_when: string[];
+  };
+  next_actions: Array<{
+    tool: string;
+    args: Record<string, unknown>;
+    why: string;
+  }>;
+  keywords: string[];
+}
+
+const WORKFLOWS: WorkflowGuide[] = [
+  {
+    id: "accounting-inbox",
+    prompt: "accounting-inbox",
+    title: "Accounting Inbox",
+    summary: "Start here when the user has a mixed workspace and wants the server to detect likely accounting inputs.",
+    when_to_use: ["mixed folder", "not sure what to do first", "month of documents", "workspace triage"],
+    primary_tools: ["run_accounting_inbox_dry_runs", "resolve_accounting_review_item", "prepare_accounting_review_action"],
+    risk_policy: {
+      default_mode: "automatic",
+      interrupt_when: ["missing bank dimension", "new accounting treatment", "duplicate cleanup", "accountant judgment"],
+    },
+    next_actions: [{
+      tool: "run_accounting_inbox_dry_runs",
+      args: {},
+      why: "Scans the workspace and automatically runs only safe discovery steps.",
+    }],
+    keywords: ["inbox", "workspace", "folder", "triage", "scan", "autopilot", "what can be done"],
+  },
+  {
+    id: "book-invoice",
+    prompt: "book-invoice",
+    title: "Book Purchase Invoice",
+    summary: "Extract, validate, duplicate-check, book, upload, and confirm a purchase invoice from a PDF/image.",
+    when_to_use: ["purchase invoice PDF", "supplier invoice", "book one invoice", "attach source document"],
+    primary_tools: [
+      "extract_pdf_invoice",
+      "validate_invoice_data",
+      "resolve_supplier",
+      "detect_duplicate_purchase_invoice",
+      "suggest_booking",
+      "create_purchase_invoice_from_pdf",
+      "confirm_purchase_invoice",
+    ],
+    risk_policy: {
+      default_mode: "confirm_once",
+      interrupt_when: ["OCR missing required fields", "new supplier", "duplicate risk", "new VAT/account treatment"],
+    },
+    next_actions: [{
+      tool: "extract_pdf_invoice",
+      args: { file_path: "<absolute invoice PDF/image path>" },
+      why: "Start with extraction so the user can review source-derived fields before booking.",
+    }],
+    keywords: ["invoice", "pdf", "supplier", "purchase", "book", "receipt", "arve"],
+  },
+  {
+    id: "import-camt",
+    prompt: "import-camt",
+    title: "Import CAMT Bank Statement",
+    summary: "Parse ISO 20022 CAMT.053 bank statements, detect duplicates, and import bank transactions.",
+    when_to_use: ["LHV/Swedbank/SEB/Coop/Luminor CAMT XML", "bank statement import", "bank transactions"],
+    primary_tools: ["parse_camt053", "import_camt053", "reconcile_inter_account_transfers"],
+    risk_policy: {
+      default_mode: "dry_run",
+      interrupt_when: ["possible duplicate", "unknown bank dimension", "inter-account transfer ambiguity"],
+    },
+    next_actions: [{
+      tool: "import_camt053",
+      args: { file_path: "<absolute CAMT.053 XML path>", accounts_dimensions_id: "<bank dimension id>", execute: false },
+      why: "Imports should preview duplicate decisions before creating transactions.",
+    }],
+    keywords: ["camt", "bank statement", "xml", "lhv", "swedbank", "seb", "coop", "luminor", "transaction import"],
+  },
+  {
+    id: "import-wise",
+    prompt: "import-wise",
+    title: "Import Wise Transactions",
+    summary: "Import regular Wise transaction-history CSV exports with fee splitting and transfer safeguards.",
+    when_to_use: ["Wise CSV", "transaction-history.csv", "Wise fees", "Wise bank account"],
+    primary_tools: ["import_wise_transactions", "reconcile_inter_account_transfers"],
+    risk_policy: {
+      default_mode: "dry_run",
+      interrupt_when: ["missing fee dimension", "ambiguous transfer target", "unsupported CSV export"],
+    },
+    next_actions: [{
+      tool: "import_wise_transactions",
+      args: { file_path: "<absolute Wise transaction-history.csv path>", accounts_dimensions_id: "<Wise bank dimension id>", execute: false },
+      why: "Wise imports should show skipped rows, fees, and transfer handling before execution.",
+    }],
+    keywords: ["wise", "csv", "transaction-history", "fee", "jar", "transfer"],
+  },
+  {
+    id: "reconcile-bank",
+    prompt: "reconcile-bank",
+    title: "Reconcile Bank Transactions",
+    summary: "Match unconfirmed bank transactions to invoices, transfers, or accounts.",
+    when_to_use: ["unmatched bank transactions", "match payments", "confirm transactions", "reconcile"],
+    primary_tools: ["reconcile_transactions", "auto_confirm_exact_matches", "reconcile_inter_account_transfers"],
+    risk_policy: {
+      default_mode: "confirm_once",
+      interrupt_when: ["partial payment", "cross-currency match", "multiple candidates", "inter-account transfer"],
+    },
+    next_actions: [{
+      tool: "reconcile_transactions",
+      args: { min_confidence: 30 },
+      why: "Show plausible matches first, then confirm only high-confidence or approved matches.",
+    }],
+    keywords: ["reconcile", "match", "unconfirmed", "payment", "bank transaction", "partial", "confirm"],
+  },
+  {
+    id: "receipt-batch",
+    prompt: "receipt-batch",
+    title: "Process Receipt Batch",
+    summary: "OCR a folder of receipts/invoices, auto-book high-confidence items, and keep ambiguous ones in review.",
+    when_to_use: ["folder of receipts", "many PDFs/images", "expense receipts", "batch booking"],
+    primary_tools: ["process_receipt_batch", "classify_unmatched_transactions", "apply_transaction_classifications"],
+    risk_policy: {
+      default_mode: "dry_run",
+      interrupt_when: ["new supplier", "OCR uncertainty", "missing VAT/account treatment", "owner expense ambiguity"],
+    },
+    next_actions: [{
+      tool: "process_receipt_batch",
+      args: { folder_path: "<absolute receipt folder path>", execute: false },
+      why: "Batch receipt processing should separate high-confidence candidates from review items first.",
+    }],
+    keywords: ["receipt", "batch", "ocr", "expenses", "folder", "images"],
+  },
+  {
+    id: "company-overview",
+    prompt: "company-overview",
+    title: "Company Overview",
+    summary: "Build a financial dashboard using balance sheet, P&L, receivables, and payables.",
+    when_to_use: ["financial overview", "dashboard", "company status", "P&L", "balance sheet"],
+    primary_tools: ["compute_balance_sheet", "compute_profit_and_loss", "compute_receivables_aging", "compute_payables_aging"],
+    risk_policy: {
+      default_mode: "automatic",
+      interrupt_when: ["unconfirmed transactions materially affect the period", "reporting period unclear"],
+    },
+    next_actions: [{
+      tool: "compute_balance_sheet",
+      args: { as_of_date: "<YYYY-MM-DD>" },
+      why: "Start with the balance sheet for the requested reporting date.",
+    }],
+    keywords: ["overview", "dashboard", "report", "balance", "profit", "loss", "aging", "financial"],
+  },
+];
+
+function normalizeGoal(goal: string | undefined): string {
+  return (goal ?? "").toLowerCase().replace(/[_-]+/g, " ").trim();
+}
+
+function scoreWorkflow(workflow: WorkflowGuide, goal: string): number {
+  if (!goal) return 0;
+  return workflow.keywords.reduce((score, keyword) => {
+    return goal.includes(keyword) ? score + Math.max(1, keyword.split(/\s+/).length) : score;
+  }, 0);
+}
+
+function compactWorkflow(workflow: WorkflowGuide): Record<string, unknown> {
+  return {
+    id: workflow.id,
+    prompt: workflow.prompt,
+    title: workflow.title,
+    summary: workflow.summary,
+    primary_tools: workflow.primary_tools,
+    default_mode: workflow.risk_policy.default_mode,
+  };
+}
+
+export function registerWorkflowRecommendationTools(server: McpServer): void {
+  registerTool(server, "recommend_workflow",
+    "Recommend the safest e-arveldaja workflow for a user goal. Use this when the user asks what to do next or when choosing among many tools.",
+    {
+      goal: z.string().optional().describe("Natural-language goal, such as 'book this invoice PDF' or 'import bank statement'. Omit to list common workflows."),
+      risk_tolerance: z.enum(["fast", "balanced", "careful"]).optional().describe("How much friction to prefer. balanced keeps boring safe steps low-friction and interrupts on risk."),
+    },
+    { ...readOnly, title: "Recommend Workflow" },
+    async ({ goal, risk_tolerance }) => {
+      const normalizedGoal = normalizeGoal(goal);
+      const ranked = WORKFLOWS
+        .map(workflow => ({ workflow, score: scoreWorkflow(workflow, normalizedGoal) }))
+        .sort((a, b) => b.score - a.score || a.workflow.id.localeCompare(b.workflow.id));
+
+      if (!normalizedGoal || ranked[0]?.score === 0) {
+        return toolResponse({
+          action: "listed",
+          entity: "workflow",
+          message: "Listed common e-arveldaja workflows. Pass goal to get a single recommendation.",
+          raw: null,
+          extra: {
+            risk_tolerance: risk_tolerance ?? "balanced",
+            available_workflows: WORKFLOWS.map(compactWorkflow),
+            workflow: buildWorkflowEnvelope({
+              summary: "Listed common e-arveldaja workflows. Pass goal to get a single recommendation.",
+              fallback_actions: [{
+                kind: "answer_question",
+                label: "Describe the accounting goal",
+                question: "What accounting task should be handled next?",
+                why: "A concrete goal lets the server choose one workflow and its first safe action.",
+                approval_required: false,
+              }],
+            }),
+          },
+        });
+      }
+
+      const best = ranked[0]!.workflow;
+      return toolResponse({
+        action: "recommended",
+        entity: "workflow",
+        id: best.id,
+        message: `Recommended ${best.title}: ${best.summary}`,
+        raw: best,
+        next_actions: best.next_actions,
+        extra: {
+          risk_tolerance: risk_tolerance ?? "balanced",
+          recommended_workflow: compactWorkflow(best),
+          risk_policy: best.risk_policy,
+          alternatives: ranked.slice(1, 4).map(entry => compactWorkflow(entry.workflow)),
+          workflow: buildWorkflowEnvelope({
+            summary: `Recommended ${best.title}: ${best.summary}`,
+            recommended_step: best.next_actions[0],
+          }),
+        },
+      });
+    }
+  );
+}

--- a/src/workflow-response.test.ts
+++ b/src/workflow-response.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { approvalPreviewFromDryRunStep, buildWorkflowEnvelope } from "./workflow-response.js";
+
+describe("workflow response helpers", () => {
+  it("prioritizes the next safe tool call before asking blocking questions", () => {
+    const workflow = buildWorkflowEnvelope({
+      summary: "Prepared inbox.",
+      needs_decision: [{
+        summary: "Which bank account dimension should be used?",
+        recommendation: "Use LHV.",
+      }],
+      recommended_step: {
+        tool: "parse_camt053",
+        suggested_args: { file_path: "/tmp/statement.xml" },
+        purpose: "Parse the CAMT statement before asking for import-only defaults.",
+      },
+    });
+
+    expect(workflow.recommended_next_action).toMatchObject({
+      kind: "tool_call",
+      tool: "parse_camt053",
+      approval_required: false,
+    });
+    expect(workflow.available_actions[1]).toMatchObject({
+      kind: "answer_question",
+      question: "Which bank account dimension should be used?",
+    });
+  });
+
+  it("creates receipt approval previews from dry-run preview counts", () => {
+    const preview = approvalPreviewFromDryRunStep({
+      tool: "process_receipt_batch",
+      summary: "Receipt dry run would create 0 invoice(s), match 0, skip 0 duplicate(s), leave 0 in review, and fail 0.",
+      suggested_args: {
+        folder_path: "/tmp/receipts",
+        accounts_dimensions_id: 100,
+        execute: false,
+      },
+      preview: {
+        created: 0,
+        matched: 0,
+        dry_run_preview: 2,
+        skipped_duplicate: 0,
+        needs_review: 0,
+        failed: 0,
+      },
+    });
+
+    expect(preview).toMatchObject({
+      title: "Approve receipt batch booking",
+      execute_tool: "process_receipt_batch",
+      execute_args: {
+        folder_path: "/tmp/receipts",
+        accounts_dimensions_id: 100,
+        execute: true,
+      },
+      accounting_impact: expect.arrayContaining(["2 purchase invoices"]),
+      source_documents: ["/tmp/receipts"],
+    });
+  });
+});

--- a/src/workflow-response.ts
+++ b/src/workflow-response.ts
@@ -1,0 +1,312 @@
+export type WorkflowActionKind =
+  | "tool_call"
+  | "answer_question"
+  | "review_item"
+  | "approve_tool_call"
+  | "done";
+
+export interface WorkflowAction {
+  kind: WorkflowActionKind;
+  label: string;
+  why: string;
+  approval_required: boolean;
+  tool?: string;
+  args?: Record<string, unknown>;
+  question?: string;
+  recommendation?: string;
+}
+
+export interface ApprovalPreview {
+  title: string;
+  summary: string;
+  approval_required: true;
+  source_tool: string;
+  execute_tool: string;
+  execute_args: Record<string, unknown>;
+  accounting_impact: string[];
+  duplicate_risk: string;
+  source_documents: string[];
+}
+
+export interface WorkflowEnvelope {
+  contract: "workflow_action_v1";
+  summary: string;
+  done: unknown[];
+  needs_decision: unknown[];
+  needs_review: unknown[];
+  recommended_next_action: WorkflowAction;
+  available_actions: WorkflowAction[];
+  approval_previews: ApprovalPreview[];
+}
+
+interface BuildWorkflowEnvelopeOptions {
+  summary: string;
+  done?: unknown[];
+  needs_decision?: unknown[];
+  needs_review?: unknown[];
+  recommended_step?: unknown;
+  approval_previews?: ApprovalPreview[];
+  fallback_actions?: WorkflowAction[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringAt(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberAt(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function arrayAt(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function recordAt(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function actionFromQuestion(question: unknown): WorkflowAction | undefined {
+  if (!isRecord(question)) return undefined;
+  const prompt = stringAt(question, "summary") ?? stringAt(question, "question");
+  if (!prompt) return undefined;
+
+  return {
+    kind: "answer_question",
+    label: "Answer the next setup question",
+    question: prompt,
+    recommendation: stringAt(question, "recommendation"),
+    why: "This missing input blocks the next safe workflow step.",
+    approval_required: false,
+  };
+}
+
+function actionFromReviewItem(reviewItem: unknown): WorkflowAction | undefined {
+  if (!isRecord(reviewItem)) return undefined;
+  const resolverInput = recordAt(reviewItem, "resolver_input") ?? reviewItem;
+  return {
+    kind: "review_item",
+    label: "Resolve the first accounting review item",
+    tool: "resolve_accounting_review_item",
+    args: { review_item_json: resolverInput },
+    why: stringAt(reviewItem, "summary") ?? "A review item needs accounting judgement before execution.",
+    recommendation: stringAt(reviewItem, "recommendation"),
+    approval_required: false,
+  };
+}
+
+export function actionFromRecommendedStep(step: unknown): WorkflowAction | undefined {
+  if (!isRecord(step)) return undefined;
+  const tool = stringAt(step, "tool");
+  if (!tool) return undefined;
+  return {
+    kind: "tool_call",
+    label: `Run ${tool}`,
+    tool,
+    args: recordAt(step, "suggested_args") ?? recordAt(step, "args") ?? {},
+    why: stringAt(step, "reason") ?? stringAt(step, "why") ?? stringAt(step, "purpose") ?? "Run the next safe workflow step.",
+    approval_required: false,
+  };
+}
+
+function actionFromApprovalPreview(preview: ApprovalPreview): WorkflowAction {
+  return {
+    kind: "approve_tool_call",
+    label: preview.title,
+    tool: preview.execute_tool,
+    args: preview.execute_args,
+    why: preview.summary,
+    approval_required: true,
+  };
+}
+
+function doneAction(): WorkflowAction {
+  return {
+    kind: "done",
+    label: "No workflow action is currently pending",
+    why: "There are no unanswered questions, review items, approval cards, or recommended dry-run steps in this response.",
+    approval_required: false,
+  };
+}
+
+export function buildWorkflowEnvelope(options: BuildWorkflowEnvelopeOptions): WorkflowEnvelope {
+  const done = options.done ?? [];
+  const needsDecision = options.needs_decision ?? [];
+  const needsReview = options.needs_review ?? [];
+  const approvalPreviews = options.approval_previews ?? [];
+  const recommendedAction = actionFromRecommendedStep(options.recommended_step);
+
+  const availableActions: WorkflowAction[] = [
+    ...approvalPreviews.map(actionFromApprovalPreview),
+    ...(recommendedAction ? [recommendedAction] : []),
+    ...needsDecision.slice(0, 1).map(actionFromQuestion).filter((action): action is WorkflowAction => action !== undefined),
+    ...needsReview.slice(0, 3).map(actionFromReviewItem).filter((action): action is WorkflowAction => action !== undefined),
+    ...(options.fallback_actions ?? []),
+  ];
+
+  return {
+    contract: "workflow_action_v1",
+    summary: options.summary,
+    done,
+    needs_decision: needsDecision,
+    needs_review: needsReview,
+    recommended_next_action: availableActions[0] ?? doneAction(),
+    available_actions: availableActions,
+    approval_previews: approvalPreviews,
+  };
+}
+
+function sourceDocuments(args: Record<string, unknown>): string[] {
+  return [args.file_path, args.folder_path]
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function withExecuteTrue(args: Record<string, unknown>): Record<string, unknown> {
+  return { ...args, execute: true };
+}
+
+function impactLine(count: number | undefined, singular: string, plural = `${singular}s`): string | undefined {
+  if (!count || count <= 0) return undefined;
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function approvalPreviewFromDryRunStep(step: unknown): ApprovalPreview | undefined {
+  if (!isRecord(step)) return undefined;
+  const tool = stringAt(step, "tool");
+  const args = recordAt(step, "suggested_args") ?? {};
+  const preview = recordAt(step, "preview");
+  if (!tool || !preview) return undefined;
+
+  if (tool === "import_camt053") {
+    const created = numberAt(preview, "created_count") ?? 0;
+    const duplicateCount = numberAt(preview, "possible_duplicate_count") ?? 0;
+    const errorCount = numberAt(preview, "error_count") ?? 0;
+    if (created <= 0 || duplicateCount > 0 || errorCount > 0) return undefined;
+    return {
+      title: "Approve CAMT transaction import",
+      summary: stringAt(step, "summary") ?? `CAMT dry run would create ${created} transaction(s).`,
+      approval_required: true,
+      source_tool: tool,
+      execute_tool: tool,
+      execute_args: withExecuteTrue(args),
+      accounting_impact: [
+        impactLine(created, "bank transaction"),
+        impactLine(numberAt(preview, "skipped_count"), "skipped row"),
+        errorCount > 0 ? `${errorCount} import error(s) must be reviewed before approval` : undefined,
+      ].filter((line): line is string => line !== undefined),
+      duplicate_risk: duplicateCount > 0
+        ? `${duplicateCount} possible duplicate(s) were reported; resolve those review items before approval.`
+        : "No possible duplicate review items were reported by the dry run.",
+      source_documents: sourceDocuments(args),
+    };
+  }
+
+  if (tool === "import_wise_transactions") {
+    const created = numberAt(preview, "created") ?? 0;
+    const errorCount = numberAt(preview, "error_count") ?? 0;
+    if (created <= 0 || errorCount > 0) return undefined;
+    return {
+      title: "Approve Wise transaction import",
+      summary: stringAt(step, "summary") ?? `Wise dry run would create ${created} transaction(s).`,
+      approval_required: true,
+      source_tool: tool,
+      execute_tool: tool,
+      execute_args: withExecuteTrue(args),
+      accounting_impact: [
+        impactLine(created, "bank transaction"),
+        impactLine(numberAt(preview, "skipped"), "skipped row"),
+        errorCount > 0 ? `${errorCount} import error(s) must be reviewed before approval` : undefined,
+      ].filter((line): line is string => line !== undefined),
+      duplicate_risk: "Review skipped rows and transfer handling before approval.",
+      source_documents: sourceDocuments(args),
+    };
+  }
+
+  if (tool === "process_receipt_batch") {
+    const created = numberAt(preview, "created") ?? 0;
+    const dryRunPreview = numberAt(preview, "dry_run_preview") ?? 0;
+    const wouldCreate = created > 0 ? created : dryRunPreview;
+    const matched = numberAt(preview, "matched") ?? 0;
+    const reviewCount = numberAt(preview, "needs_review") ?? 0;
+    const failed = numberAt(preview, "failed") ?? 0;
+    if ((wouldCreate <= 0 && matched <= 0) || reviewCount > 0 || failed > 0) return undefined;
+    return {
+      title: "Approve receipt batch booking",
+      summary: stringAt(step, "summary") ?? `Receipt dry run would create ${wouldCreate} invoice(s).`,
+      approval_required: true,
+      source_tool: tool,
+      execute_tool: tool,
+      execute_args: withExecuteTrue(args),
+      accounting_impact: [
+        impactLine(wouldCreate, "purchase invoice"),
+        impactLine(matched, "matched transaction"),
+        impactLine(numberAt(preview, "skipped_duplicate"), "skipped duplicate"),
+        reviewCount > 0 ? `${reviewCount} receipt(s) still need review before approval` : undefined,
+        failed > 0 ? `${failed} receipt(s) failed and should be fixed before approval` : undefined,
+      ].filter((line): line is string => line !== undefined),
+      duplicate_risk: reviewCount > 0 || failed > 0
+        ? "Review unresolved receipt items before approving execution."
+        : "No unresolved receipt review items were reported by the dry run.",
+      source_documents: sourceDocuments(args),
+    };
+  }
+
+  if (tool === "apply_transaction_classifications") {
+    const wouldCreate = numberAt(preview, "would_create") ?? numberAt(preview, "dry_run_preview") ?? 0;
+    const failed = numberAt(preview, "failed") ?? 0;
+    if (wouldCreate <= 0 || failed > 0) return undefined;
+    return {
+      title: "Approve transaction classification booking",
+      summary: stringAt(step, "summary") ?? `Classification dry run would create ${wouldCreate} invoice(s).`,
+      approval_required: true,
+      source_tool: tool,
+      execute_tool: tool,
+      execute_args: withExecuteTrue(args),
+      accounting_impact: [
+        impactLine(wouldCreate, "purchase invoice"),
+        impactLine(numberAt(preview, "skipped"), "skipped classification"),
+        failed > 0 ? `${failed} classification group(s) failed and should be fixed before approval` : undefined,
+      ].filter((line): line is string => line !== undefined),
+      duplicate_risk: "Review the classification source groups before approving execution.",
+      source_documents: sourceDocuments(args),
+    };
+  }
+
+  return undefined;
+}
+
+export function approvalPreviewsFromDryRunSteps(steps: unknown[]): ApprovalPreview[] {
+  return steps
+    .map(approvalPreviewFromDryRunStep)
+    .filter((preview): preview is ApprovalPreview => preview !== undefined);
+}
+
+export function workflowFromAccountingInboxPayload(payload: Record<string, unknown>): WorkflowEnvelope {
+  const autopilot = recordAt(payload, "autopilot");
+  if (autopilot) {
+    return buildWorkflowEnvelope({
+      summary: stringAt(autopilot, "user_summary") ?? "Accounting inbox has a workflow state.",
+      done: arrayAt(autopilot, "done_automatically"),
+      needs_decision: arrayAt(autopilot, "needs_one_decision"),
+      needs_review: arrayAt(autopilot, "needs_accountant_review"),
+      recommended_step: recordAt(autopilot, "next_recommended_action"),
+      approval_previews: approvalPreviewsFromDryRunSteps(arrayAt(autopilot, "executed_steps")),
+    });
+  }
+
+  const preparedInbox = recordAt(payload, "prepared_inbox") ?? payload;
+  return buildWorkflowEnvelope({
+    summary: stringAt(preparedInbox, "user_summary") ?? "Prepared accounting inbox workflow.",
+    done: [],
+    needs_decision: arrayAt(preparedInbox, "questions"),
+    needs_review: [],
+    recommended_step: recordAt(preparedInbox, "next_recommended_action"),
+  });
+}


### PR DESCRIPTION
## What changed

This PR adds a user-facing workflow action contract across the e-arveldaja MCP server so tools can return a clear next action instead of requiring callers to infer what to do from raw payloads.

Highlights:
- Adds reusable workflow and tool response helpers.
- Adds `recommend_workflow` for choosing the right accounting flow from a user goal.
- Adds approval previews for safe dry-run to execute transitions.
- Adds top-level workflow envelopes to CAMT, Wise, receipt batch, and transaction classification batch tools.
- Improves HTTP/client and CRUD ergonomics used by the workflow responses.
- Updates docs and changelog for the new workflow behavior.

## Why

The process was hard to drive from an assistant UI because dry runs, review items, questions, and execution approvals were spread across tool-specific payloads. The new contract makes the next step explicit and keeps mutating execution behind an approval action.

## Validation

- `npm run validate:release`
- `npm test`
- `npm run test:integration`
