### PR TITLE
Throttle progress notifications to keep Claude Code transport alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Long-running tools crashed the Claude Code MCP transport with "Received a progress notification for an unknown token"** — call sites in `camt-import`, `bank-reconciliation`, `receipt-inbox`, `wise-import`, `analyze-unconfirmed`, `lightyear-investments`, and `api/base-resource` invoked `reportProgress` once per item across loops of 50–69+ entries. Each emit was awaited but landed in the OS stdio buffer; on slow clients the response was matched and the progressToken handler cleared *before* the trailing notifications were drained, and Claude Code treats any "unknown token" progress notification as a fatal transport error (closes the stdio pipe; the user must reconnect via `/mcp`). `reportProgress` now (a) throttles to at most one notification per 100 ms within an invocation, (b) skips the trailing `progress >= total` emit since the response itself signals completion, and (c) honors a `EARVELDAJA_DISABLE_PROGRESS=1` env-var kill switch for environments still affected. Throttle state is per-invocation (WeakMap keyed by the SDK's tool extra), so concurrent tool calls and back-to-back invocations never share a window.
+
 ## [0.12.2] - 2026-04-26
 
 ### Fixed

--- a/server.json
+++ b/server.json
@@ -51,6 +51,13 @@
           "isRequired": false,
           "isSecret": false,
           "format": "string"
+        },
+        {
+          "name": "EARVELDAJA_DISABLE_PROGRESS",
+          "description": "Set to \"1\" or \"true\" to disable MCP progress notifications. Workaround for clients that close the stdio transport when a progress notification arrives after the matching response has been processed.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
         }
       ]
     }

--- a/src/progress.test.ts
+++ b/src/progress.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { reportProgress, toolExtraStorage } from "./progress.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { reportProgress, toolExtraStorage, type ToolExtra } from "./progress.js";
 
 describe("reportProgress", () => {
   it("sends progress notifications when the client supplies progressToken=0", async () => {
@@ -33,5 +33,90 @@ describe("reportProgress", () => {
     });
 
     expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("throttles bursts of progress notifications within an invocation", async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const extra: ToolExtra = { sendNotification, _meta: { progressToken: "tok" } };
+
+    await toolExtraStorage.run(extra, async () => {
+      for (let i = 1; i < 50; i++) await reportProgress(i, 100);
+    });
+
+    // First call goes through; the rest land within the throttle window
+    // (100ms) and are dropped. The final i=49 is below total=100 so it is
+    // still subject to throttling, not the trailing-100% skip.
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification).toHaveBeenCalledWith({
+      method: "notifications/progress",
+      params: { progressToken: "tok", progress: 1, total: 100 },
+    });
+  });
+
+  it("re-enables emission after the throttle window elapses", async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const extra: ToolExtra = { sendNotification, _meta: { progressToken: "tok" } };
+
+    let nowMs = 1_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      await toolExtraStorage.run(extra, async () => {
+        await reportProgress(1, 100);
+        nowMs += 200; // past the 100ms throttle
+        await reportProgress(2, 100);
+      });
+      expect(sendNotification).toHaveBeenCalledTimes(2);
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  it("skips the trailing progress=total notification (response signals completion)", async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+
+    await toolExtraStorage.run({
+      sendNotification,
+      _meta: { progressToken: 0 },
+    }, async () => {
+      await reportProgress(2, 2);
+    });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips emission when EARVELDAJA_DISABLE_PROGRESS=1", async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const original = process.env.EARVELDAJA_DISABLE_PROGRESS;
+    process.env.EARVELDAJA_DISABLE_PROGRESS = "1";
+    try {
+      await toolExtraStorage.run({
+        sendNotification,
+        _meta: { progressToken: 0 },
+      }, async () => {
+        await reportProgress(1, 2);
+      });
+      expect(sendNotification).not.toHaveBeenCalled();
+    } finally {
+      process.env.EARVELDAJA_DISABLE_PROGRESS = original;
+    }
+  });
+
+  it("isolates throttle state per invocation (different extras)", async () => {
+    const sendA = vi.fn().mockResolvedValue(undefined);
+    const sendB = vi.fn().mockResolvedValue(undefined);
+
+    await toolExtraStorage.run({ sendNotification: sendA, _meta: { progressToken: "a" } }, async () => {
+      await reportProgress(1, 100);
+      await reportProgress(2, 100); // throttled
+    });
+
+    await toolExtraStorage.run({ sendNotification: sendB, _meta: { progressToken: "b" } }, async () => {
+      // Fresh invocation — first emit goes through even if it is within
+      // 100ms of the previous invocation's emit.
+      await reportProgress(1, 100);
+    });
+
+    expect(sendA).toHaveBeenCalledTimes(1);
+    expect(sendB).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -8,14 +8,49 @@ export interface ToolExtra {
 export const toolExtraStorage = new AsyncLocalStorage<ToolExtra>();
 
 /**
+ * Minimum interval between emitted progress notifications within a single
+ * tool invocation. Tight per-item loops (50 CAMT entries, 69 reconcile rows,
+ * etc.) would otherwise flood the stdio transport. Any notification that
+ * arrives at the client *after* the tool's response is matched gets dropped
+ * with "Received a progress notification for an unknown token" — and on
+ * Claude Code that drop is fatal: the transport is closed and the server
+ * must be reconnected. Throttling cuts the volume and shrinks the race
+ * window; the trailing 100% emit is also skipped because the response itself
+ * already signals completion.
+ *
+ * Set EARVELDAJA_DISABLE_PROGRESS=1 to disable progress entirely on clients
+ * that still mishandle late-arriving events.
+ */
+const PROGRESS_THROTTLE_MS = 100;
+
+const lastEmitByExtra = new WeakMap<ToolExtra, number>();
+
+function progressDisabled(): boolean {
+  const v = process.env.EARVELDAJA_DISABLE_PROGRESS;
+  return v === "1" || v === "true";
+}
+
+/**
  * Report progress for long-running operations.
  * No-op if the client didn't supply a progress token.
  */
 export async function reportProgress(progress: number, total?: number): Promise<void> {
+  if (progressDisabled()) return;
   const extra = toolExtraStorage.getStore();
   if (!extra) return;
   const progressToken = extra?._meta?.progressToken;
   if (progressToken === undefined) return;
+
+  // Skip the trailing 100% notification: the response signals completion,
+  // and the final emit is the most likely to lose the race against it.
+  if (total !== undefined && progress >= total) return;
+
+  // Throttle within an invocation: at most one notification per window.
+  const now = Date.now();
+  const last = lastEmitByExtra.get(extra) ?? 0;
+  if (now - last < PROGRESS_THROTTLE_MS) return;
+  lastEmitByExtra.set(extra, now);
+
   try {
     await extra.sendNotification({
       method: "notifications/progress",


### PR DESCRIPTION
## Summary
- Long-running iterating tools (`process_receipt_batch`, `reconcile_transactions`, `import_camt053` over 50+ entries, `bank-reconciliation`, `wise-import`, `analyze_unconfirmed_transactions`, `lightyear-investments`, `api/base-resource` pagination) emit one progress notification per item. Each emit was awaited but landed in the OS stdio buffer; the response was matched and the progressToken handler cleared *before* the trailing notifications were drained, and Claude Code treats any \"unknown progress token\" notification as a fatal transport error — the stdio pipe is closed and the user must reconnect via `/mcp`.
- Confirmed during a real bookkeeping session this evening: three transport closes, all on iterating bulk tools (`process_receipt_batch`, `reconcile_transactions`, `process_receipt_batch` again). Logs show the burst of \"Received a progress notification for an unknown token\" notifications arriving ~500 ms *after* the tool returned its response.
- Fix is fully in `reportProgress`: throttle to ≤1 notification / 100 ms per invocation (per-invocation `WeakMap` state keyed on the SDK's tool extra), skip the trailing `progress >= total` emit (the response itself signals completion, and the final emit is the most race-prone), and add a `EARVELDAJA_DISABLE_PROGRESS=1` env-var kill switch documented in `server.json`. No call-site changes needed.

## Evidence
From `~/.cache/claude-cli-nodejs/-home-seppo-Dokumendid-seppoai/mcp-logs-e-arveldaja/2026-04-26T00-49-17-255Z.jsonl`:

```
00:53:02.803  Calling MCP tool: process_receipt_batch
00:53:06.557  Tool 'process_receipt_batch' completed successfully in 3s
00:53:07.021  Connection error: Received a progress notification for an unknown token: {progressToken:11, progress:25/50}
…  (one entry per item, all timestamped 00:53:07.021)
00:53:07.021  Closing transport (stdio transport error: Error)
```

Same pattern at 01:03:41 for `reconcile_transactions` (progressToken 18, 0–28+/69), and again later in the session.

## Test plan
- [x] `npx vitest run src/progress.test.ts` — 7 passed (5 new)
- [x] `npx vitest run` — full suite 1021 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: re-run `process_receipt_batch` and `reconcile_transactions` against Claude Code with this build; confirm no transport close

🤖 Generated with [Claude Code](https://claude.com/claude-code)