### PR TITLE
Pre-seed progress throttle baseline at invocation start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Claude Code MCP transport still dropped on fast paginated tools after 0.12.3** — the 100 ms throttle introduced in 0.12.3 only suppressed the *second and later* `reportProgress` calls within an invocation. The first emit always passed (the throttle map's default is 0, so `Date.now() - 0` is far larger than 100 ms), so any tool whose first `await reportProgress(...)` fired right after a fast page-1 fetch still raced its own response. Production logs from 2026-04-26 captured three drops in one session (`list_transactions`, `detect_duplicate_purchase_invoice`, `reconcile_inter_account_transfers`) where the tool completed in 7–42 ms and the leading `progress: 0` notification arrived at the client *after* the response had cleared the progressToken — Claude Code closed the stdio transport and the server had to reconnect. The throttle baseline is now pre-seeded to invocation start via a new `runWithExtra` wrapper around `toolExtraStorage.run`, so tools that finish inside the 100 ms window emit zero progress notifications. Slow tools (>100 ms first-emit latency) still report progress as before.
+
 ## [0.12.4] - 2026-04-26
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
   type CredentialStorageScope,
   type Config,
 } from "./config.js";
-import { toolExtraStorage } from "./progress.js";
+import { runWithExtra } from "./progress.js";
 import { HttpClient } from "./http-client.js";
 import { ClientsApi } from "./api/clients.api.js";
 import { ProductsApi } from "./api/products.api.js";
@@ -871,7 +871,7 @@ Reporting:
             await ensureAuditLogLabelResolved(snapshot.index);
           }
           const runInExtra = extra
-            ? () => toolExtraStorage.run(extra, () => handler(...args))
+            ? () => runWithExtra(extra, () => handler(...args))
             : () => handler(...args);
           return runInExtra();
         });

--- a/src/progress.test.ts
+++ b/src/progress.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { reportProgress, toolExtraStorage, type ToolExtra } from "./progress.js";
+import { reportProgress, runWithExtra, toolExtraStorage, type ToolExtra } from "./progress.js";
 
 describe("reportProgress", () => {
   it("sends progress notifications when the client supplies progressToken=0", async () => {
@@ -98,6 +98,75 @@ describe("reportProgress", () => {
       expect(sendNotification).not.toHaveBeenCalled();
     } finally {
       process.env.EARVELDAJA_DISABLE_PROGRESS = original;
+    }
+  });
+
+  it("runWithExtra suppresses progress emitted within the leading throttle window", async () => {
+    // Reproduces the production race: paginated tools that complete in
+    // <100 ms (e.g. cached `list_transactions` with 6 pages) used to emit
+    // `progress: 0` on the first page fetch. That notification arrived at
+    // the client *after* the response, the SDK had already cleared the
+    // progressToken, and Claude Code closed the transport. Pre-seeding the
+    // throttle baseline at invocation start keeps the emit silent.
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const extra: ToolExtra = { sendNotification, _meta: { progressToken: "tok" } };
+
+    let nowMs = 1_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      await runWithExtra(extra, async () => {
+        nowMs += 1; // 1 ms into invocation — fast page fetch
+        await reportProgress(0, 6);
+        nowMs += 50; // 51 ms in — still inside the leading window
+        await reportProgress(1, 6);
+        nowMs += 40; // 91 ms in — still inside
+        await reportProgress(2, 6);
+      });
+      expect(sendNotification).not.toHaveBeenCalled();
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  it("runWithExtra emits once the leading throttle window has elapsed", async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const extra: ToolExtra = { sendNotification, _meta: { progressToken: "tok" } };
+
+    let nowMs = 1_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      await runWithExtra(extra, async () => {
+        nowMs += 150; // past the 100 ms leading window
+        await reportProgress(1, 6);
+      });
+      expect(sendNotification).toHaveBeenCalledTimes(1);
+      expect(sendNotification).toHaveBeenCalledWith({
+        method: "notifications/progress",
+        params: { progressToken: "tok", progress: 1, total: 6 },
+      });
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  it("runWithExtra emits at the exact +100 ms boundary (strict-less-than throttle)", async () => {
+    // Pin the boundary: `now - last < PROGRESS_THROTTLE_MS` is strict, so an
+    // emit at exactly +100 ms is allowed. Defends against an accidental flip
+    // to `<=`, which would re-open the leading-window race for tools that
+    // first attempt to emit at the threshold.
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const extra: ToolExtra = { sendNotification, _meta: { progressToken: "tok" } };
+
+    let nowMs = 1_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      await runWithExtra(extra, async () => {
+        nowMs += 100;
+        await reportProgress(1, 6);
+      });
+      expect(sendNotification).toHaveBeenCalledTimes(1);
+    } finally {
+      dateSpy.mockRestore();
     }
   });
 

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -18,12 +18,39 @@ export const toolExtraStorage = new AsyncLocalStorage<ToolExtra>();
  * window; the trailing 100% emit is also skipped because the response itself
  * already signals completion.
  *
+ * The throttle baseline is also pre-seeded to invocation start by
+ * `runWithExtra` (see below): any tool that completes inside the first
+ * window emits zero progress notifications, eliminating the race for the
+ * common case of fast paginated fetches (`list_transactions` over a few
+ * pages typically finishes in <50 ms).
+ *
  * Set EARVELDAJA_DISABLE_PROGRESS=1 to disable progress entirely on clients
  * that still mishandle late-arriving events.
  */
 const PROGRESS_THROTTLE_MS = 100;
 
 const lastEmitByExtra = new WeakMap<ToolExtra, number>();
+
+/**
+ * Wrap a tool handler so that progress emits are scoped to this invocation
+ * AND the throttle baseline starts at invocation entry. The baseline is the
+ * key fix for the "unknown progress token" transport drops: without it, the
+ * very first `reportProgress` call always passes throttle (because the map
+ * defaults to 0), which loses the race against fast-completing tools — the
+ * notification arrives at the client after the response has already cleared
+ * the progressToken, and Claude Code closes the transport.
+ *
+ * Replaces direct `toolExtraStorage.run(extra, fn)` at all production
+ * callsites. Tests that exercise the throttle window directly can still use
+ * `toolExtraStorage.run` to bypass the leading-window suppression.
+ */
+export function runWithExtra<T>(
+  extra: ToolExtra,
+  fn: () => Promise<T>,
+): Promise<T> {
+  lastEmitByExtra.set(extra, Date.now());
+  return toolExtraStorage.run(extra, fn);
+}
 
 function progressDisabled(): boolean {
   const v = process.env.EARVELDAJA_DISABLE_PROGRESS;


### PR DESCRIPTION
## Summary

The 100 ms throttle that landed in #25 / 0.12.3 only suppressed the *second and later* `reportProgress` calls within an invocation. The first emit always passed (the WeakMap default is `0`, so `Date.now() - 0` is far larger than 100 ms), so any tool whose first `await reportProgress(...)` fired right after a fast page-1 fetch still raced its own response.

Production session 2026-04-26 (sessionId `e2f1d6fb`) captured three drops with exactly this shape:

| Time | Tool | Wall-clock duration | progressToken | total |
|------|------|---------------------|---------------|-------|
| 19:37:44 | `list_transactions` | 7 ms | 18 | 6 |
| 19:39:43 | `detect_duplicate_purchase_invoice` | 8 ms | 7 | 2 |
| 19:56:45 | `reconcile_inter_account_transfers` | 42 ms | 24 | 7 |

Each one emitted `progress: 0` on the first page fetch; the notification arrived at the client *after* the response had cleared the `progressToken`; Claude Code closed the stdio transport with `Received a progress notification for an unknown token`. The server respawned with a new pid each time (962052 → 977518 → 988731 → 1154112 in `/tmp/earveldaja-mcp.err.log` via the new `EARVELDAJA_LOG_FILE`).

## Fix

A new `runWithExtra(extra, fn)` helper in `progress.ts` wraps `toolExtraStorage.run` and calls `lastEmitByExtra.set(extra, Date.now())` at invocation entry. The throttle baseline is now **invocation start** rather than the epoch, so any `reportProgress` call inside the leading 100 ms window is silently dropped. Tools that complete inside that window — which includes all three above — emit zero progress notifications and cannot trigger the unknown-token race.

Slow tools (>100 ms first-emit latency) report progress as before: same 100 ms throttle semantics, just measured from invocation start instead of the first attempted emit.

Single production callsite swap at `src/index.ts:874` (the only `toolExtraStorage.run` callsite under `src/` outside tests). `toolExtraStorage` stays exported so existing unit tests that drive the throttle directly retain their bypass.

## Test plan

- [x] `npm test` — 1040 unit tests pass (was 1037, +3 new)
- [x] `npm run build` — clean TypeScript build
- [x] New tests pin both halves of the invariant:
  - `runWithExtra suppresses progress emitted within the leading throttle window` — drives `Date.now()` via `vi.spyOn`, attempts emits at +1, +51, +91 ms inside `runWithExtra`, asserts zero `sendNotification` calls
  - `runWithExtra emits once the leading throttle window has elapsed` — advances 150 ms, asserts one emit with the right shape
  - `runWithExtra emits at the exact +100 ms boundary` — defends the strict-less-than comparison so an accidental flip to `<=` re-opens the race and trips the test
- [x] Independent code review (Claude code-reviewer subagent): APPROVE, no blockers
- [ ] Manual verification on the user's live `seppoai` accounting session: re-run a `list_transactions` / `reconcile_inter_account_transfers` flow that previously dropped, confirm no `Closing transport (stdio transport error: Error)` lines in `~/.cache/claude-cli-nodejs/-home-seppo-Dokumendid-seppoai/mcp-logs-e-arveldaja/*.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)