### PR TITLE
Fix macOS receipt file references

### DIFF
--- a/src/tools/receipt-inbox-files.ts
+++ b/src/tools/receipt-inbox-files.ts
@@ -119,7 +119,9 @@ async function openBoundReceiptDirectory(
 
     const binding = {
       canonicalPath,
-      accessPath: descriptorPath ?? canonicalPath,
+      accessPath: process.platform === "darwin"
+        ? canonicalPath
+        : descriptorPath ?? canonicalPath,
       ...(descriptorPath !== undefined ? { descriptorPath } : {}),
       handle,
     };

--- a/src/tools/receipt-inbox-files.ts
+++ b/src/tools/receipt-inbox-files.ts
@@ -74,10 +74,10 @@ async function assertReceiptDirectoryBinding(binding: BoundReceiptDirectory): Pr
 }
 
 /**
- * Bind the exact directory object, not merely its path string. Linux/macOS
- * descriptor paths keep all enumeration and reads relative to the retained
- * no-follow handle. If descriptor-relative access is unavailable, fail closed:
- * falling back to another pathname lookup would re-open the TOCTOU window.
+ * Bind the exact directory object, not merely its path string. Linux descriptor
+ * paths keep all enumeration and reads relative to the retained no-follow
+ * handle. macOS exposes directory handles under /dev/fd, but Node cannot
+ * traverse them, so Darwin uses the portable opened-object identity checks.
  */
 async function openBoundReceiptDirectory(
   folderPath: string,
@@ -109,11 +109,11 @@ async function openBoundReceiptDirectory(
         // Try the next platform descriptor namespace.
       }
     }
-    // Opaque references require descriptor-relative access: weakening them to
-    // a second pathname lookup would recreate the exact path-retarget race the
-    // reference is meant to close. Direct folder_path calls retain portable
-    // support with an opened-object identity check before/after pathname work.
-    if (!descriptorPath && options.expectedCanonicalPath !== undefined) {
+    // Opaque references normally require descriptor-relative access. Darwin's
+    // /dev/fd directory handles are not traversable in Node (readdir is ENOTDIR),
+    // so use the same before/after identity checks as direct folder_path calls.
+    if (!descriptorPath && options.expectedCanonicalPath !== undefined &&
+      process.platform !== "darwin") {
       throw receiptDirectoryChanged();
     }
 

--- a/src/tools/receipt-inbox-path.test.ts
+++ b/src/tools/receipt-inbox-path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { win32 } from "path";
 import { parseMcpResponse } from "../mcp-json.js";
 import type { registerReceiptInboxTools as registerReceiptInboxToolsType } from "./receipt-inbox.js";
@@ -37,6 +37,14 @@ const { registerReceiptInboxTools } = await import("./receipt-inbox.js") as {
   registerReceiptInboxTools: typeof registerReceiptInboxToolsType;
 };
 
+const hostPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+afterEach(() => setPlatform(hostPlatform));
+
 describe("receipt inbox folder path validation", () => {
   it("accepts Windows-style child folders under an allowed root", async () => {
     const server = { registerTool: vi.fn() } as any;
@@ -54,7 +62,25 @@ describe("receipt inbox folder path validation", () => {
     expect(payload.skipped).toEqual([]);
   });
 
-  it("fails closed for an expected reference binding when descriptor namespaces are unavailable", async () => {
+  it("uses portable expected-reference binding on macOS when descriptor paths are unavailable", async () => {
+    setPlatform("darwin");
+
+    await expect(scanReceiptFolderInternal(
+      "C:\\Allowed\\Receipts",
+      undefined,
+      undefined,
+      undefined,
+      { expectedCanonicalPath: "C:\\Allowed\\Receipts" },
+    )).resolves.toMatchObject({
+      folder_path: "C:\\Allowed\\Receipts",
+      files: [],
+      skipped: [],
+    });
+  });
+
+  it("fails closed on other platforms when descriptor namespaces are unavailable", async () => {
+    setPlatform("win32");
+
     await expect(scanReceiptFolderInternal(
       "C:\\Allowed\\Receipts",
       undefined,

--- a/src/tools/receipt-inbox-path.test.ts
+++ b/src/tools/receipt-inbox-path.test.ts
@@ -7,7 +7,8 @@ import { scanReceiptFolderInternal } from "./receipt-inbox-files.js";
 
 vi.mock("fs/promises", () => ({
   realpath: vi.fn().mockImplementation(async (path: unknown) => {
-    if (String(path).startsWith("/proc/") || String(path).startsWith("/dev/fd/")) {
+    if (String(path).startsWith("/proc/") ||
+      (String(path).startsWith("/dev/fd/") && process.platform !== "darwin")) {
       throw Object.assign(new Error("descriptor namespace unavailable"), { code: "ENOENT" });
     }
     return "C:\\Allowed\\Receipts";
@@ -18,7 +19,12 @@ vi.mock("fs/promises", () => ({
     stat: vi.fn().mockResolvedValue({ isDirectory: () => true, dev: 1, ino: 2 }),
     close: vi.fn().mockResolvedValue(undefined),
   }),
-  readdir: vi.fn().mockResolvedValue([]),
+  readdir: vi.fn().mockImplementation(async (path: unknown) => {
+    if (String(path).startsWith("/dev/fd/")) {
+      throw Object.assign(new Error("descriptor path is not traversable"), { code: "ENOTDIR" });
+    }
+    return [];
+  }),
   readFile: vi.fn(),
 }));
 
@@ -62,7 +68,7 @@ describe("receipt inbox folder path validation", () => {
     expect(payload.skipped).toEqual([]);
   });
 
-  it("uses portable expected-reference binding on macOS when descriptor paths are unavailable", async () => {
+  it("uses portable expected-reference binding on macOS when the descriptor path is not traversable", async () => {
     setPlatform("darwin");
 
     await expect(scanReceiptFolderInternal(


### PR DESCRIPTION
## Summary

- Use the existing portable directory binding for opaque receipt references on macOS.
- Keep descriptor-relative binding and fail-closed behavior on other platforms.
- Add regression coverage for both paths.

## Why

Node exposes macOS directory handles under `/dev/fd`, but they are not traversable (`readdir` returns `ENOTDIR`). Valid receipt `file_ref` values therefore failed with `file_reference_path_changed`.

The Darwin fallback keeps the existing directory identity checks before and after access. Per-file `O_NOFOLLOW` and approved-manifest checks are unchanged.

## Tested

- `npm test` — 3431 passed
- `npm run build`
- `npm run test:integration` — 20 passed, 3 skipped
- `npm run validate:release`
- Reopened the same opaque `file_ref` twice against an iCloud Drive receipt folder on macOS
