### PR TITLE
Fix the macOS receipt ref regression after #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Opaque receipt `file_ref` values reopen on real macOS filesystems.** The 0.25.2 hardening assumed `realpath("/dev/fd/N")` returned the receipt directory's canonical pathname on Darwin. Node 24 and 26 instead return a synthetic `/dev/fd/<directory-name>` path while `readdir("/dev/fd/N")` remains `ENOTDIR`, so the descriptor was rejected and every opaque receipt reference failed with `file_reference_path_changed`. A successfully resolved Darwin `/dev/fd/N` now keeps the descriptor requirement without comparing its synthetic spelling to the canonical pathname; enumeration still uses the canonical path guarded by opened-object identity checks.
+
+### Security
+
+- **Per-file receipt binding no longer depends on descriptor `realpath` spelling.** Every opened receipt is now checked by filesystem object identity (`fstat` on the `O_NOFOLLOW` handle versus `stat` on the canonical file path) before its bytes are read. This keeps the per-file check active on Darwin's canonical-path fallback, preserves descriptor-relative access elsewhere, and applies the same opened-object check to direct folder paths.
+
 ## [0.25.3] - 2026-07-26
 
 ### Fixed

--- a/src/receipts/batch-operations.test.ts
+++ b/src/receipts/batch-operations.test.ts
@@ -35,6 +35,8 @@ vi.mock("fs/promises", async (importOriginal) => {
         stat: vi.fn().mockResolvedValue({
           isDirectory: () => !isFile,
           isFile: () => isFile,
+          dev: 1,
+          ino: isFile ? 3 : 2,
           size: isFile ? 512 : 0,
         }),
         readFile: vi.fn().mockImplementation(() => readFileMock(path)),
@@ -91,9 +93,14 @@ function primeFilesystem(): void {
   vi.mocked(realpath).mockImplementation(receiptRealpath as never);
   vi.mocked(readdir).mockResolvedValue([{ name: "receipt.pdf", isFile: () => true }] as never);
   vi.mocked(stat).mockImplementation(async (path) => {
-    if (String(path) === FOLDER) return { isDirectory: () => true } as never;
+    if (String(path) === FOLDER) {
+      return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as never;
+    }
     return {
       isDirectory: () => false,
+      isFile: () => true,
+      dev: 1,
+      ino: 3,
       size: 512,
       mtime: new Date("2026-03-20T10:00:00.000Z"),
     } as never;

--- a/src/tools/receipt-batch-failure.test.ts
+++ b/src/tools/receipt-batch-failure.test.ts
@@ -34,6 +34,8 @@ vi.mock("fs/promises", async (importOriginal) => {
         stat: vi.fn().mockResolvedValue({
           isDirectory: () => !isFile,
           isFile: () => isFile,
+          dev: 1,
+          ino: isFile ? 3 : 2,
           size: isFile ? 512 : 0,
         }),
         readFile: vi.fn().mockImplementation(() => readFileMock(path)),
@@ -124,11 +126,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -280,8 +285,8 @@ describe("process_receipt_batch rollback handling", () => {
     vi.mocked(realpath).mockImplementation(receiptRealpath as any);
     vi.mocked(readdir).mockResolvedValue([{ name: "receipt.pdf", isFile: () => true }] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
-      if (String(path) === "/tmp/receipts") return { isDirectory: () => true } as any;
-      return { isDirectory: () => false, size: 512, mtime: new Date("2026-07-15T10:00:00.000Z") } as any;
+      if (String(path) === "/tmp/receipts") return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
+      return { isDirectory: () => false, isFile: () => true, dev: 1, ino: 3, size: 512, mtime: new Date("2026-07-15T10:00:00.000Z") } as any;
     });
     vi.mocked(readFile).mockResolvedValue(Buffer.from("receipt pdf") as any);
     vi.mocked(resolveFilePath).mockImplementation((path) => path);
@@ -358,11 +363,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -515,11 +523,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -693,11 +704,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -837,11 +851,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -1020,11 +1037,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -1182,11 +1202,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -1342,11 +1365,14 @@ describe("process_receipt_batch rollback handling", () => {
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
       if (String(path) === "/tmp/receipts") {
-        return { isDirectory: () => true } as any;
+        return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       }
 
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-03-20T10:00:00.000Z"),
       } as any;
@@ -1498,9 +1524,12 @@ describe("process_receipt_batch rollback handling", () => {
       { name: "anthropic.pdf", isFile: () => true },
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
-      if (String(path) === "/tmp/receipts") return { isDirectory: () => true } as any;
+      if (String(path) === "/tmp/receipts") return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-04-20T10:00:00.000Z"),
       } as any;
@@ -1653,9 +1682,12 @@ describe("process_receipt_batch rollback handling", () => {
       { name: "receipt.pdf", isFile: () => true },
     ] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
-      if (String(path) === "/tmp/receipts") return { isDirectory: () => true } as any;
+      if (String(path) === "/tmp/receipts") return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
       return {
         isDirectory: () => false,
+        isFile: () => true,
+        dev: 1,
+        ino: 3,
         size: 512,
         mtime: new Date("2026-04-20T10:00:00.000Z"),
       } as any;
@@ -1738,8 +1770,8 @@ describe("process_receipt_batch own-company identity protection (M09)", () => {
     vi.mocked(realpath).mockImplementation(receiptRealpath as any);
     vi.mocked(readdir).mockResolvedValue([{ name: "receipt.pdf", isFile: () => true }] as any);
     vi.mocked(stat).mockImplementation(async (path) => {
-      if (String(path) === "/tmp/receipts") return { isDirectory: () => true } as any;
-      return { isDirectory: () => false, size: 512, mtime: new Date("2026-07-15T10:00:00.000Z") } as any;
+      if (String(path) === "/tmp/receipts") return { isDirectory: () => true, isFile: () => false, dev: 1, ino: 2 } as any;
+      return { isDirectory: () => false, isFile: () => true, dev: 1, ino: 3, size: 512, mtime: new Date("2026-07-15T10:00:00.000Z") } as any;
     });
     vi.mocked(readFile).mockResolvedValue(Buffer.from("receipt pdf") as any);
     vi.mocked(resolveFilePath).mockImplementation((path) => path);

--- a/src/tools/receipt-inbox-files.ts
+++ b/src/tools/receipt-inbox-files.ts
@@ -53,6 +53,10 @@ function receiptDirectoryChanged(): FileReferenceStoreError {
   return new FileReferenceStoreError("file_reference_path_changed");
 }
 
+function isDarwinDescriptorPath(path: string): boolean {
+  return process.platform === "darwin" && path.startsWith("/dev/fd/");
+}
+
 async function assertReceiptDirectoryBinding(binding: BoundReceiptDirectory): Promise<void> {
   try {
     const [openedInfo, currentInfo] = await Promise.all([
@@ -63,9 +67,16 @@ async function assertReceiptDirectoryBinding(binding: BoundReceiptDirectory): Pr
       !sameFilesystemObject(openedInfo, currentInfo)) {
       throw receiptDirectoryChanged();
     }
-    if (binding.descriptorPath !== undefined &&
-      await realpath(binding.descriptorPath) !== binding.canonicalPath) {
-      throw receiptDirectoryChanged();
+    if (binding.descriptorPath !== undefined) {
+      const descriptorRealPath = await realpath(binding.descriptorPath);
+      // Darwin exposes the retained fd as /dev/fd/<directory-name>, not as the
+      // directory's canonical pathname. The handle-vs-path stat check above is
+      // the opened-object identity proof there; realpath only proves that the
+      // descriptor namespace remains available.
+      if (descriptorRealPath !== binding.canonicalPath &&
+        !isDarwinDescriptorPath(binding.descriptorPath)) {
+        throw receiptDirectoryChanged();
+      }
     }
   } catch (error) {
     if (error instanceof FileReferenceStoreError) throw error;
@@ -106,7 +117,8 @@ async function openBoundReceiptDirectory(
     let descriptorPath: string | undefined;
     for (const candidate of [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]) {
       try {
-        if (await realpath(candidate) === canonicalPath) {
+        const descriptorRealPath = await realpath(candidate);
+        if (descriptorRealPath === canonicalPath || isDarwinDescriptorPath(candidate)) {
           descriptorPath = candidate;
           break;
         }
@@ -114,13 +126,11 @@ async function openBoundReceiptDirectory(
         // Try the next platform descriptor namespace.
       }
     }
-    // Opaque references still require a resolvable descriptor path on every
-    // platform, macOS included. Darwin only needs the enumeration below to go
-    // through the pathname; it does NOT need this check relaxed, because
-    // realpath on /dev/fd succeeds there even though readdir does not. Waiving
-    // it would also waive the per-file verification in readBoundReceiptFile,
-    // which is gated on `descriptorPath` being present — an opaque reference
-    // would then be checked strictly less than a direct folder_path call.
+    // Opaque references require a resolvable descriptor namespace on every
+    // platform, macOS included. Darwin's /dev/fd realpath has a synthetic
+    // spelling, but resolving the exact retained fd is sufficient because the
+    // opened directory and every opened child are independently identity-
+    // checked against their canonical paths.
     if (!descriptorPath && options.expectedCanonicalPath !== undefined) {
       throw receiptDirectoryChanged();
     }
@@ -288,25 +298,11 @@ async function readBoundReceiptFile(
   try {
     handle = await open(candidatePath, constants.O_RDONLY | constants.O_NOFOLLOW);
     const openedInfo = await handle.stat();
-    if (!openedInfo.isFile() || openedInfo.size > MAX_RECEIPT_SIZE) {
+    const currentInfo = await stat(file.path);
+    if (!openedInfo.isFile() || !currentInfo.isFile() ||
+      openedInfo.size > MAX_RECEIPT_SIZE ||
+      !sameFilesystemObject(openedInfo, currentInfo)) {
       throw receiptDirectoryChanged();
-    }
-
-    if (binding.descriptorPath !== undefined) {
-      let openedCanonicalPath: string | undefined;
-      for (const descriptorPath of [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]) {
-        try {
-          openedCanonicalPath = await realpath(descriptorPath);
-          break;
-        } catch {
-          // Try the next platform descriptor namespace.
-        }
-      }
-      const roots = getAllowedRoots();
-      if (openedCanonicalPath !== file.path ||
-        !roots.some(root => isPathWithinRoot(openedCanonicalPath, root))) {
-        throw receiptDirectoryChanged();
-      }
     }
 
     const bytes = await handle.readFile();

--- a/src/tools/receipt-inbox-path.test.ts
+++ b/src/tools/receipt-inbox-path.test.ts
@@ -12,6 +12,11 @@ vi.mock("fs/promises", () => ({
       (String(path).startsWith("/dev/fd/") && process.platform !== "darwin")) {
       throw Object.assign(new Error("descriptor namespace unavailable"), { code: "ENOENT" });
     }
+    if (String(path).startsWith("/dev/fd/")) {
+      // Real Darwin returns a synthetic descriptor pathname rather than the
+      // canonical directory pathname.
+      return "/dev/fd/Receipts";
+    }
     return "C:\\Allowed\\Receipts";
   }),
   stat: vi.fn().mockResolvedValue({ isDirectory: () => true, dev: 1, ino: 2 }),
@@ -86,11 +91,9 @@ describe("receipt inbox folder path validation", () => {
   });
 
   it("fails closed on macOS too when no descriptor namespace resolves at all", async () => {
-    // The Darwin fallback exists only because /dev/fd is not traversable, not
-    // because it is absent — realpath on it still succeeds there. If it ever
-    // stops resolving, an opaque reference must fail rather than degrade: with
-    // no descriptorPath, readBoundReceiptFile skips its per-file opened-object
-    // verification, leaving the reference checked less than a direct call.
+    // The Darwin fallback exists because /dev/fd is not traversable, not
+    // because it is absent. If it ever stops resolving, an opaque reference
+    // must fail rather than silently lose its retained-descriptor binding.
     setPlatform("darwin");
     const mockedRealpath = vi.mocked(realpath) as unknown as Mock;
     const descriptorless = async (path: unknown): Promise<string> => {

--- a/src/tools/receipt-inbox-tools.test.ts
+++ b/src/tools/receipt-inbox-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { registerReceiptInboxTools } from "./receipt-inbox.js";
@@ -890,6 +890,32 @@ describe("receipt inbox tool status handling", () => {
       rmSync(replacementPath, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform === "darwin")(
+    "reopens and snapshots an opaque receipt path with the real Darwin descriptor filesystem",
+    async () => {
+      const folder = createReceiptFolder({ "receipt.pdf": "%PDF-1.4\nDARWIN" });
+      const canonicalFolder = realpathSync(folder);
+      let snapshot: Awaited<ReturnType<typeof prepareReceiptBatchSnapshot>> | undefined;
+
+      try {
+        snapshot = await prepareReceiptBatchSnapshot(
+          canonicalFolder,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { expectedCanonicalPath: canonicalFolder },
+        );
+
+        expect(snapshot.scan.files.map(file => file.name)).toEqual(["receipt.pdf"]);
+        expect(snapshot.files[0]!.bytes.toString()).toBe("%PDF-1.4\nDARWIN");
+      } finally {
+        await snapshot?.cleanup();
+        rmSync(folder, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("never snapshots outside bytes when a validated receipt child becomes a symlink", async () => {
     const folder = createReceiptFolder({ "receipt.pdf": "%PDF-1.4\nORIGINAL" });


### PR DESCRIPTION
Follow-up to #56. The first fix was fine, but the hardening added before 0.25.2 made the same path fail again on mac.

The regression came from the assumption that `realpath("/dev/fd/N")` returns the directory's canonical path on macOS. Checked on both Node 24.14.0 and 26.5.0, Darwin actually returns `/dev/fd/<directory-name>`; trying to enumerate `/dev/fd/N` still fails with `ENOTDIR`. Because of the string comparison, `descriptorPath` never gets set and every opaque receipt ref is rejected as `file_reference_path_changed`.

The descriptor requirement still fails closed if neither descriptor namespace resolves. Directory enumeration still uses the canonical path on Darwin. Per-file verification now compares the opened `O_NOFOLLOW` handle with the current canonical file by filesystem identity (`dev` + `ino`), so that check also works on Darwin.

Coverage:

- mocked Darwin test now returns the same synthetic path as the real OS
- Darwin-only test uses the actual `/dev/fd` behavior and snapshots a receipt through the opaque-reference path