### PR TITLE
Fix the remaining macOS test failures

### DIFF
--- a/src/__fixtures__/accounting-workflow.ts
+++ b/src/__fixtures__/accounting-workflow.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { mkdtempSync, writeFileSync } from "fs";
-import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { mkdtempSync, realpathSync, writeFileSync } from "fs";
+import { mkdir, mkdtemp, realpath, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { vi } from "vitest";
@@ -309,9 +309,9 @@ export function createReceiptFolder(files: Record<string, string> = { "receipt.p
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(join(root, name), contents, "utf-8");
   }
-  return root;
+  return realpathSync(root);
 }
 
 async function mkdirTemp(prefix: string): Promise<string> {
-  return mkdtemp(join(tmpdir(), prefix));
+  return realpath(await mkdtemp(join(tmpdir(), prefix)));
 }

--- a/src/__integration__/mcp-connection.integration.test.ts
+++ b/src/__integration__/mcp-connection.integration.test.ts
@@ -221,7 +221,7 @@ describe("MCP Server Integration", () => {
     const afterData = parseMcpResponse((after.content as any)[0].text);
 
     expect(validationMessage).toMatch(/index/i);
-    expect(validationMessage).toMatch(/\bint(?:eger)?\b|safeint/i);
+    expect(validationMessage).toMatch(/\b(?:int(?:eger)?|safeint)\b/i);
     expect(afterData.active).toBe(beforeData.active);
   });
 

--- a/src/__integration__/mcp-connection.integration.test.ts
+++ b/src/__integration__/mcp-connection.integration.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "fs";
 import { rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -208,22 +208,20 @@ describe("MCP Server Integration", () => {
     const before = await client.callTool({ name: "list_connections", arguments: {} });
     const beforeData = parseMcpResponse((before.content as any)[0].text);
 
-    let sawValidationFailure = false;
+    let validationMessage = "";
     try {
       const result = await client.callTool({ name: "switch_connection", arguments: { index: 0.5 } });
-      const resultData = parseMcpResponse((result.content as any)[0].text);
       expect(result.isError).toBe(true);
-      expect(String((resultData as { error?: unknown }).error ?? JSON.stringify(resultData))).toMatch(/integer/i);
-      sawValidationFailure = true;
+      validationMessage = String((result.content as any)[0]?.text ?? "");
     } catch (error) {
-      expect(String(error)).toMatch(/integer/i);
-      sawValidationFailure = true;
+      validationMessage = String(error);
     }
 
     const after = await client.callTool({ name: "list_connections", arguments: {} });
     const afterData = parseMcpResponse((after.content as any)[0].text);
 
-    expect(sawValidationFailure).toBe(true);
+    expect(validationMessage).toMatch(/index/i);
+    expect(validationMessage).toMatch(/\bint(?:eger)?\b|safeint/i);
     expect(afterData.active).toBe(beforeData.active);
   });
 
@@ -390,9 +388,11 @@ describe("MCP Server Setup Mode", () => {
   let client: Client;
   let transport: StdioClientTransport;
   let tempDir: string;
+  let canonicalTempDir: string;
 
   beforeAll(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "earveldaja-mcp-setup-"));
+    canonicalTempDir = realpathSync(tempDir);
     transport = createTransport({
       cwd: tempDir,
       env: buildTransportEnv({
@@ -451,7 +451,7 @@ describe("MCP Server Setup Mode", () => {
     expect(data.active).toBeNull();
     expect(data.total).toBe(0);
     expect(data.setup_required).toBe(true);
-    expect(data.working_directory).toBe(tempDir);
+    expect(data.working_directory).toBe(canonicalTempDir);
     expect(data.hint).toContain("get_setup_instructions");
   });
 
@@ -461,7 +461,7 @@ describe("MCP Server Setup Mode", () => {
 
     expect(setup.isError).toBeFalsy();
     expect(setupData.mode).toBe("setup");
-    expect(setupData.working_directory).toBe(tempDir);
+    expect(setupData.working_directory).toBe(canonicalTempDir);
     expect(setupData.credential_file_pattern).toBe("apikey*.txt");
     expect(setupData.credential_file_env_var).toBe("EARVELDAJA_API_KEY_FILE");
     expect(setupData.env_vars).toEqual(expect.arrayContaining([
@@ -478,7 +478,7 @@ describe("MCP Server Setup Mode", () => {
     expect(blockedData.hint).toContain("get_setup_instructions");
     expect(blockedData.blocked_tool).toBe("get_vat_info");
     expect(blockedData.blocked_api_method).toBe("readonly.getVatInfo");
-    expect(blockedData.working_directory).toBe(tempDir);
+    expect(blockedData.working_directory).toBe(canonicalTempDir);
   });
 
   it("falls back cleanly when interactive credential prompting is unavailable", async () => {
@@ -507,7 +507,7 @@ describe("MCP Server Setup Mode", () => {
     expect(data.error).toContain("setup mode");
     expect(data.blocked_resource).toBe("earveldaja://accounts");
     expect(data.blocked_api_method).toBe("readonly.getAccounts");
-    expect(data.working_directory).toBe(tempDir);
+    expect(data.working_directory).toBe(canonicalTempDir);
   });
 
   it("still allows local offline tools in setup mode", async () => {

--- a/src/file-input-snapshot.test.ts
+++ b/src/file-input-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -161,7 +161,7 @@ describe("captureFileInputSnapshot", () => {
     await writeFile(path, "a,b\n");
     const context = runtime();
     const fileRef = context.fileReferenceStore.issue({
-      canonicalPath: path,
+      canonicalPath: await realpath(path),
       kind: "file",
       operation: FILE_REFERENCE_OPERATIONS.wise,
     });

--- a/src/file-validation.test.ts
+++ b/src/file-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { getAllowedRootsStartupWarning, isPathWithinRoot, resolveFileInput, splitAllowedPaths, validateFilePath } from "./file-validation.js";
-import { writeFileSync, mkdirSync, symlinkSync, unlinkSync, rmdirSync, existsSync, readFileSync, rmSync } from "fs";
+import { writeFileSync, mkdirSync, symlinkSync, unlinkSync, rmdirSync, existsSync, readFileSync, realpathSync, rmSync } from "fs";
 import { join, win32, extname, resolve } from "path";
 import { tmpdir } from "os";
 
@@ -144,7 +144,7 @@ describe("validateFilePath", () => {
     try {
       const module = await import("./file-validation.js");
       const result = await module.validateFilePath("statement.csv", [".csv"], 1024);
-      expect(result).toBe(resolve(allowedRoot, "statement.csv"));
+      expect(result).toBe(realpathSync(resolve(allowedRoot, "statement.csv")));
     } finally {
       vi.doUnmock("./paths.js");
       vi.resetModules();

--- a/src/guided/process-accounting-document.test.ts
+++ b/src/guided/process-accounting-document.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -32,7 +32,7 @@ function docWithRegCode(): Awaited<ReturnType<typeof parseDocument>> {
 
 const tempDirs: string[] = [];
 function writeTempPdf(contents = "%PDF-1.4 fixture"): { path: string; sha256: string } {
-  const dir = mkdtempSync(join(tmpdir(), "doc-facade-")); tempDirs.push(dir);
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "doc-facade-"))); tempDirs.push(dir);
   const path = join(dir, "invoice.pdf"); writeFileSync(path, contents);
   return { path, sha256: createHash("sha256").update(Buffer.from(contents)).digest("hex") };
 }

--- a/src/guided/process-bank-input.test.ts
+++ b/src/guided/process-bank-input.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -131,7 +131,7 @@ describe("process_bank_input", () => {
 
   it("accepts a bank_input file_ref and rejects a camt_input ref passed to the façade", async () => {
     const { handler, runtime } = setup();
-    const dir = await mkdtemp(join(tmpdir(), "bank-facade-"));
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "bank-facade-")));
     const xmlPath = join(dir, "statement.xml");
     await writeFile(xmlPath, fixtureCamtXml(), "utf8");
 


### PR DESCRIPTION
Follow-up to #58. Once the receipt path itself is fixed, the test suite still has a couple of mac-only assumptions.

The `switch_connection` integration test treats the MCP SDK's own validation error like one of our formatted server responses. It is actually plain `MCP error ...` text, and the current SDK says `int` / `safeint` rather than necessarily spelling out `integer`. The test now checks the returned or thrown SDK message directly, including the `index` field.

The other failures are the usual Darwin temp-path alias: `mkdtemp` gives tests `/var/folders/...`, while code that calls `realpath` returns `/private/var/folders/...`. Test fixtures and setup-mode assertions now use the canonical path, which is the value the production code is supposed to return/store.

No production behavior changes here.

Checked on mac with this branch on top of #58:
- `npm test` — 4,087 passed
- `npm run test:integration` — 20 passed, 3 skipped
- `npm run build`
- `npm run validate:release`